### PR TITLE
Breaking: Add RabbitFlowMessageContext to consumers (v5)

### DIFF
--- a/sample/RabbitFlowSample/Consumers/EmailConsumer.cs
+++ b/sample/RabbitFlowSample/Consumers/EmailConsumer.cs
@@ -1,4 +1,5 @@
 using EasyRabbitFlow.Services;
+using EasyRabbitFlow.Settings;
 using EasyRabbitFlow.Exceptions;
 using RabbitFlowSample.Events;
 using System.Text.Json;
@@ -7,8 +8,12 @@ namespace RabbitFlowSample.Consumers;
 
 public class EmailConsumer(ILogger<EmailConsumer> logger) : IRabbitFlowConsumer<NotificationEvent>
 {
-    public async Task HandleAsync(NotificationEvent message, CancellationToken cancellationToken)
+    public async Task HandleAsync(NotificationEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
     {
+        // Access AMQP metadata via the message context parameter
+        logger.LogInformation("[EmailSend] Processing message. MessageId={MessageId}, Redelivered={Redelivered}",
+            context.MessageId ?? "(none)", context.Redelivered);
+
         if (message.EmailNotificationData is null)
         {
             logger.LogInformation("[EmailSend] No email data. Skipping.");

--- a/sample/RabbitFlowSample/Consumers/WhatsAppConsumer.cs
+++ b/sample/RabbitFlowSample/Consumers/WhatsAppConsumer.cs
@@ -1,4 +1,5 @@
 using EasyRabbitFlow.Services;
+using EasyRabbitFlow.Settings;
 using RabbitFlowSample.Events;
 using System.Text.Json;
 
@@ -10,7 +11,7 @@ public class WhatsAppConsumer(
     GuidTransientService guidTransientService,
     ILogger<WhatsAppConsumer> logger) : IRabbitFlowConsumer<NotificationEvent>
 {
-    public async Task HandleAsync(NotificationEvent message, CancellationToken cancellationToken)
+    public async Task HandleAsync(NotificationEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
     {
         var scopedGuid = guidScopedService.Guid;
 

--- a/src/RabbitFlow/EasyRabbitFlow.csproj
+++ b/src/RabbitFlow/EasyRabbitFlow.csproj
@@ -6,7 +6,7 @@
 		<Title>EasyRabbitFlow</Title>
 		<Authors>Juan Carlos Torres Cuervo</Authors>
 		<Description>EasyRabbitFlow: high-performance RabbitMQ client for .NET. Fluent configuration, optional topology (queue/exchange/dead-letter) generation, reflection-free consumers, configurable retry (exponential/backoff), custom dead-letter routing, temporary batch processing, queue state helpers. Targets .NET Standard 2.1.</Description>
-		<Version>4.2.0</Version>
+		<Version>5.0.0</Version>
 		<PackageTags>rabbitmq;dotnet;messaging;queue;consumer;publisher;retry;deadletter;backoff;temporary;batch</PackageTags>
 		<PackageProjectUrl>https://github.com/devjuanca/EasyRabbitFlow</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/devjuanca/EasyRabbitFlow</RepositoryUrl>

--- a/src/RabbitFlow/Services/ConsumerHostedService.cs
+++ b/src/RabbitFlow/Services/ConsumerHostedService.cs
@@ -290,12 +290,21 @@ namespace EasyRabbitFlow.Services
                         var attemptCt = linked.Token;
                         
                         using var scope = _root.CreateScope();
-                        
+
                         try
                         {
+                            var messageContext = new RabbitFlowMessageContext(
+                                args.BasicProperties?.MessageId,
+                                args.BasicProperties?.CorrelationId,
+                                args.Exchange,
+                                args.RoutingKey,
+                                args.BasicProperties?.Headers,
+                                args.DeliveryTag,
+                                args.Redelivered);
+
                             var consumer = scope.ServiceProvider.GetRequiredService(consumerType);
-                            
-                            await markerFactory.InvokeHandleAsync(consumer, evt, attemptCt).ConfigureAwait(false);
+
+                            await markerFactory.InvokeHandleAsync(consumer, evt, messageContext, attemptCt).ConfigureAwait(false);
                             
                             await SafeAckAsync(channel, channelGate, args.DeliveryTag, rootCt);
                             

--- a/src/RabbitFlow/Services/IRabbitFlowConsumer.cs
+++ b/src/RabbitFlow/Services/IRabbitFlowConsumer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using EasyRabbitFlow.Settings;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EasyRabbitFlow.Services
@@ -17,13 +18,9 @@ namespace EasyRabbitFlow.Services
         /// This method is called when a message of type <typeparamref name="TEvent"/> is received from the RabbitMQ queue.
         /// </summary>
         /// <param name="message">The message to handle, containing the event data.</param>
+        /// <param name="context">The AMQP metadata of the received message, including <c>MessageId</c>, <c>CorrelationId</c>, headers, and delivery information.</param>
         /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
         /// <returns>A task representing the asynchronous message handling process.</returns>
-        /// <remarks>
-        /// Implement this method to define the logic for processing RabbitMQ messages of the specified event type.
-        /// The <paramref name="cancellationToken"/> can be used to cancel the operation if needed, such as when shutting down.
-        /// Ensure to handle exceptions and potentially implement retry logic within this method to manage message processing failures.
-        /// </remarks>
-        Task HandleAsync(TEvent message, CancellationToken cancellationToken);
+        Task HandleAsync(TEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken);
     }
 }

--- a/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
+++ b/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
@@ -24,11 +24,12 @@ namespace EasyRabbitFlow.Services
         /// <param name="message">The message to publish.</param>
         /// <param name="exchangeName">The name of the exchange to publish the message to.</param>
         /// <param name="routingKey">The routing key for the message.</param>
+        /// <param name="correlationId">An optional correlation identifier for tracing related messages.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="PublishResult"/> describing the outcome of the publish operation.</returns>
-        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string exchangeName, string routingKey, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string exchangeName, string routingKey, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
 
         /// <summary>
@@ -38,11 +39,12 @@ namespace EasyRabbitFlow.Services
         /// <typeparam name="TEvent">The type of the message to publish.</typeparam>
         /// <param name="message">The message to publish.</param>
         /// <param name="queueName">The name of the queue to publish the message to.</param>
+        /// <param name="correlationId">An optional correlation identifier for tracing related messages.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="PublishResult"/> describing the outcome of the publish operation.</returns>
-        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string queueName, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string queueName, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
         /// <summary>
         /// Asynchronously publishes a batch of messages to a RabbitMQ exchange.
@@ -58,11 +60,12 @@ namespace EasyRabbitFlow.Services
         /// <param name="exchangeName">The name of the exchange to publish messages to.</param>
         /// <param name="routingKey">The routing key for the messages.</param>
         /// <param name="channelMode">The channel mode for the batch operation. Defaults to <see cref="ChannelMode.Transactional"/>.</param>
+        /// <param name="correlationId">An optional correlation identifier shared by all messages in the batch.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="BatchPublishResult"/> describing the outcome of the batch publish operation.</returns>
-        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
         /// <summary>
         /// Asynchronously publishes a batch of messages to a RabbitMQ queue.
@@ -77,11 +80,12 @@ namespace EasyRabbitFlow.Services
         /// <param name="messages">The collection of messages to publish.</param>
         /// <param name="queueName">The name of the queue to publish messages to.</param>
         /// <param name="channelMode">The channel mode for the batch operation. Defaults to <see cref="ChannelMode.Transactional"/>.</param>
+        /// <param name="correlationId">An optional correlation identifier shared by all messages in the batch.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="BatchPublishResult"/> describing the outcome of the batch publish operation.</returns>
-        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
     }
 
     internal sealed class RabbitFlowPublisher : IRabbitFlowPublisher
@@ -107,27 +111,27 @@ namespace EasyRabbitFlow.Services
             this.publisherOptions = publisherOptions ?? new PublisherOptions();
         }
 
-        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string exchangeName, string routingKey = "", string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string exchangeName, string routingKey = "", string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishMessageAsync(@event, exchangeName, routingKey, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
+            return await PublishMessageAsync(@event, exchangeName, routingKey, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
         }
 
-        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string queueName, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string queueName, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishMessageAsync(@event, queueName, "", publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
+            return await PublishMessageAsync(@event, queueName, "", correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
         }
 
-        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishBatchInternalAsync(messages, exchangeName, routingKey, channelMode, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
+            return await PublishBatchInternalAsync(messages, exchangeName, routingKey, channelMode, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
         }
 
-        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishBatchInternalAsync(messages, queueName, "", channelMode, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
+            return await PublishBatchInternalAsync(messages, queueName, "", channelMode, correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
         }
 
-        private async Task<PublishResult> PublishMessageAsync<TEvent>(TEvent @event, string destination, string routingKey, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
+        private async Task<PublishResult> PublishMessageAsync<TEvent>(TEvent @event, string destination, string routingKey, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
         {
             if (@event is null)
             {
@@ -146,7 +150,7 @@ namespace EasyRabbitFlow.Services
 
             try
             {
-                await PublishToChannelAsync(channel, @event, destination, routingKey, serializerOptions, isQueue, messageId, cancellationToken);
+                await PublishToChannelAsync(channel, @event, destination, routingKey, serializerOptions, isQueue, messageId, correlationId, cancellationToken);
 
                 logger.LogDebug("[RABBIT-FLOW]: Message of type {MessageType} published to {Destination}. MessageId={MessageId}",
                     typeof(TEvent).FullName, destination, messageId ?? "(none)");
@@ -168,7 +172,7 @@ namespace EasyRabbitFlow.Services
             }
         }
 
-        private async Task<BatchPublishResult> PublishBatchInternalAsync<TEvent>(IReadOnlyList<TEvent> messages, string destination, string routingKey, ChannelMode channelMode, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
+        private async Task<BatchPublishResult> PublishBatchInternalAsync<TEvent>(IReadOnlyList<TEvent> messages, string destination, string routingKey, ChannelMode channelMode, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
         {
             if (messages is null || messages.Count == 0)
             {
@@ -205,7 +209,7 @@ namespace EasyRabbitFlow.Services
 
                     string? messageId = publisherOptions.IdempotencyEnabled ? Guid.NewGuid().ToString("N") : null;
 
-                    await PublishToChannelAsync(channel, msg, destination, routingKey, serializerOptions, isQueue, messageId, cancellationToken);
+                    await PublishToChannelAsync(channel, msg, destination, routingKey, serializerOptions, isQueue, messageId, correlationId, cancellationToken);
 
                     if (messageId != null)
                     {
@@ -251,7 +255,7 @@ namespace EasyRabbitFlow.Services
         }
 
 
-        private ValueTask PublishToChannelAsync<TEvent>(IChannel channel, TEvent @event, string destination, string routingKey, JsonSerializerOptions serializerOptions, bool isQueue, string? messageId, CancellationToken cancellationToken = default) where TEvent : class
+        private ValueTask PublishToChannelAsync<TEvent>(IChannel channel, TEvent @event, string destination, string routingKey, JsonSerializerOptions serializerOptions, bool isQueue, string? messageId, string? correlationId, CancellationToken cancellationToken = default) where TEvent : class
         {
             var body = JsonSerializer.SerializeToUtf8Bytes(@event, serializerOptions);
 
@@ -259,9 +263,13 @@ namespace EasyRabbitFlow.Services
 
             var rk = isQueue ? destination : routingKey;
 
-            if (messageId != null)
+            if (messageId != null || correlationId != null)
             {
-                var properties = new BasicProperties { MessageId = messageId };
+                var properties = new BasicProperties
+                {
+                    MessageId = messageId,
+                    CorrelationId = correlationId
+                };
 
                 return channel.BasicPublishAsync(exchange, rk, false, properties, body, cancellationToken);
             }

--- a/src/RabbitFlow/Settings/IConsumerSettingsMarker.cs
+++ b/src/RabbitFlow/Settings/IConsumerSettingsMarker.cs
@@ -31,7 +31,7 @@ namespace EasyRabbitFlow.Settings
     internal sealed class ConsumerSettingsFactory
     {
         public Func<ReadOnlyMemory<byte>, JsonSerializerOptions, object?> Deserialize { get; set; } = default!;
-        public Func<object, object, CancellationToken, Task> InvokeHandleAsync { get; set; } = default!;
+        public Func<object, object, RabbitFlowMessageContext, CancellationToken, Task> InvokeHandleAsync { get; set; } = default!;
         public Func<object, string, IServiceProvider, Task>? PublishToCustomDeadletter { get; set; }
     }
 }

--- a/src/RabbitFlow/Settings/RabbitFlowMessageContext.cs
+++ b/src/RabbitFlow/Settings/RabbitFlowMessageContext.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+
+namespace EasyRabbitFlow.Settings
+{
+    /// <summary>
+    /// Provides access to AMQP metadata of the message currently being processed by a consumer.
+    /// Passed as a parameter to <c>HandleAsync</c> alongside the deserialized message body.
+    /// </summary>
+    public sealed class RabbitFlowMessageContext
+    {
+        internal RabbitFlowMessageContext(
+            string? messageId,
+            string? correlationId,
+            string? exchange,
+            string? routingKey,
+            IDictionary<string, object?>? headers,
+            ulong deliveryTag,
+            bool redelivered)
+        {
+            MessageId = messageId;
+            CorrelationId = correlationId;
+            Exchange = exchange;
+            RoutingKey = routingKey;
+            Headers = headers;
+            DeliveryTag = deliveryTag;
+            Redelivered = redelivered;
+        }
+
+        /// <summary>
+        /// Gets the <c>MessageId</c> from <c>BasicProperties</c>.
+        /// When the publisher has <see cref="PublisherOptions.IdempotencyEnabled"/> set to <c>true</c>,
+        /// this contains the unique identifier assigned to the message for deduplication.
+        /// <c>null</c> when the publisher did not set a <c>MessageId</c>.
+        /// </summary>
+        public string? MessageId { get; }
+
+        /// <summary>
+        /// Gets the <c>CorrelationId</c> from <c>BasicProperties</c>.
+        /// Useful for tracing request/reply flows or correlating related messages.
+        /// </summary>
+        public string? CorrelationId { get; }
+
+        /// <summary>
+        /// Gets the exchange that delivered the message.
+        /// Empty string when the message was published directly to a queue.
+        /// </summary>
+        public string? Exchange { get; }
+
+        /// <summary>
+        /// Gets the routing key used when the message was published.
+        /// </summary>
+        public string? RoutingKey { get; }
+
+        /// <summary>
+        /// Gets the AMQP headers from <c>BasicProperties</c>.
+        /// <c>null</c> when no custom headers were set by the publisher.
+        /// </summary>
+        public IDictionary<string, object?>? Headers { get; }
+
+        /// <summary>
+        /// Gets the delivery tag assigned by the broker for this message.
+        /// </summary>
+        public ulong DeliveryTag { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this message was redelivered by the broker.
+        /// </summary>
+        public bool Redelivered { get; }
+    }
+}

--- a/tests/EasyRabbitFlow.Tests/Helpers/TestTypes.cs
+++ b/tests/EasyRabbitFlow.Tests/Helpers/TestTypes.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using EasyRabbitFlow.Services;
+using EasyRabbitFlow.Settings;
 
 namespace EasyRabbitFlow.Tests.Helpers;
 
@@ -15,7 +16,7 @@ public class TestConsumer : IRabbitFlowConsumer<TestEvent>
 
     public static IReadOnlyList<TestEvent> ReceivedMessages => _received.ToList();
 
-    public Task HandleAsync(TestEvent message, CancellationToken cancellationToken)
+    public Task HandleAsync(TestEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
     {
         _received.Add(message);
         return Task.CompletedTask;
@@ -34,7 +35,7 @@ public class TransientFailConsumer : IRabbitFlowConsumer<TestEvent>
 
     public static IReadOnlyList<TestEvent> ReceivedMessages => _received.ToList();
 
-    public Task HandleAsync(TestEvent message, CancellationToken cancellationToken)
+    public Task HandleAsync(TestEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
     {
         var count = Interlocked.Increment(ref _callCount);
 


### PR DESCRIPTION
- IRabbitFlowConsumer<TEvent>.HandleAsync now requires a RabbitFlowMessageContext parameter, providing AMQP metadata (MessageId, CorrelationId, headers, delivery info) to consumers.
- Introduce RabbitFlowMessageContext class; pass it to all consumers.
- All publish methods now accept an optional correlationId for end-to-end tracing; publisher sets CorrelationId and MessageId on BasicProperties.
- Batch publishing supports correlationId for all messages in the batch.
- Update all consumer implementations, tests, and documentation for the new signature.
- Bump package version to 5.0.0 and document breaking changes and migration steps.
- Highlight PublisherOptions.IdempotencyEnabled and enable it in the sample.
- Update internal DI and delegate wiring to support the new context parameter.
- Prepare codebase for richer tracing, deduplication, and header-based workflows.