### PR TITLE
Add onError delegate to IRabbitFlowTemporary and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,38 @@ public class InvoiceService
 }
 ```
 
+### Error Handling with `onError`
+
+The `onError` callback is invoked whenever a message fails during processing (timeout, cancellation, or exception). Use it to decide what to do with failed messages — log them, persist them, or republish to another queue:
+
+```csharp
+int processed = await _temporary.RunAsync(
+    invoices,
+    onMessageReceived: async (invoice, ct) =>
+    {
+        await ProcessInvoiceAsync(invoice, ct);
+    },
+    onCompleted: (total, errors) =>
+    {
+        Console.WriteLine($"Done! Processed: {total}, Errors: {errors}");
+    },
+    onError: async (failedInvoice, ct) =>
+    {
+        // Store the failed message for later retry or manual review
+        await _failedMessageStore.SaveAsync(failedInvoice, ct);
+
+        // Or republish to a dead-letter queue
+        await _publisher.PublishAsync(failedInvoice, "invoices-failed-queue");
+    },
+    options: new RunTemporaryOptions
+    {
+        PrefetchCount = 10,
+        Timeout = TimeSpan.FromSeconds(30)
+    });
+```
+
+> **Note:** If `onError` itself throws, the exception is caught and logged internally — it will not break the batch processing flow.
+
 ### With Result Collection
 
 ```csharp
@@ -814,6 +846,10 @@ int processed = await _temporary.RunAsync<Invoice, InvoiceResult>(
         // results is a ConcurrentQueue<InvoiceResult> with all collected results
         Console.WriteLine($"Processed {count} invoices, collected {results.Count} results");
         await SaveResultsAsync(results);
+    },
+    onError: async (failedInvoice, ct) =>
+    {
+        await _failedMessageStore.SaveAsync(failedInvoice, ct);
     });
 ```
 
@@ -825,8 +861,10 @@ int processed = await _temporary.RunAsync<Invoice, InvoiceResult>(
 
   RunAsync(messages) ─────►  Create temp queue  ───────────►  onMessageReceived()
        │                     Publish all msgs                      │
-       │                           │                               │
-       │                     Consume & process  ◄──────────────────┘
+       │                           │                          ┌────┴────┐
+       │                           │                        success   failure
+       │                           │                          │         │
+       │                     Consume & process  ◄─────────────┘    onError()
        │                           │
        │                     All processed?
        │                           │ yes

--- a/sample/RabbitFlowSample/Program.cs
+++ b/sample/RabbitFlowSample/Program.cs
@@ -155,11 +155,16 @@ app.MapPost("/volatile", async (int count, [FromServices] IRabbitFlowTemporary r
         onMessageReceived: async (@event, msgCt) =>
         {
             await Task.Delay(TimeSpan.FromMilliseconds(250), msgCt);
+            throw new Exception("Simulated processing error");
             logger.LogInformation("Processed volatile event {Id}", @event.Id);
         },
         onCompleted: (totalProcessed, errors) =>
         {
             logger.LogInformation("Volatile batch completed. Total={Total}, Errors={Errors}", totalProcessed, errors);
+        },
+        onError: async (@event, errorCt) =>
+        {
+            logger.LogWarning("Failed to process volatile event {Id}", @event.Id);
         },
         options: new RunTemporaryOptions
         {
@@ -191,6 +196,12 @@ app.MapPost("/volatile-fire-and-forget", async (int count, [FromServices] IRabbi
         onCompleted: (totalProcessed, errors) =>
         {
             logger.LogInformation("Volatile batch completed. Total={Total}, Errors={Errors}", totalProcessed, errors);
+        },
+        onError: (@event, errorCt) =>
+        {
+            logger.LogWarning("Failed to process volatile event {Id}", @event.Id);
+
+            return Task.CompletedTask;
         },
         options: new RunTemporaryOptions
         {

--- a/src/RabbitFlow/EasyRabbitFlow.csproj
+++ b/src/RabbitFlow/EasyRabbitFlow.csproj
@@ -6,7 +6,7 @@
 		<Title>EasyRabbitFlow</Title>
 		<Authors>Juan Carlos Torres Cuervo</Authors>
 		<Description>EasyRabbitFlow: high-performance RabbitMQ client for .NET. Fluent configuration, optional topology (queue/exchange/dead-letter) generation, reflection-free consumers, configurable retry (exponential/backoff), custom dead-letter routing, temporary batch processing, queue state helpers. Targets .NET Standard 2.1.</Description>
-		<Version>5.0.0</Version>
+		<Version>5.1.0</Version>
 		<PackageTags>rabbitmq;dotnet;messaging;queue;consumer;publisher;retry;deadletter;backoff;temporary;batch</PackageTags>
 		<PackageProjectUrl>https://github.com/devjuanca/EasyRabbitFlow</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/devjuanca/EasyRabbitFlow</RepositoryUrl>

--- a/src/RabbitFlow/Services/IRabbitFlowTemporary.cs
+++ b/src/RabbitFlow/Services/IRabbitFlowTemporary.cs
@@ -14,593 +14,642 @@ using System.Threading.Tasks;
 namespace EasyRabbitFlow.Services
 {
 
-public interface IRabbitFlowTemporary
-{
-    /// <summary>
-    /// Publishes a collection of messages to a temporary RabbitMQ exchange and consumes them asynchronously.
-    /// Each message is processed using the provided handler function, with support for cancellation and per-message timeout.
-    /// An optional completion callback can be invoked once all messages have been processed.
-    /// </summary>
-    /// <typeparam name="T">The type of messages to process. Must be a reference type.</typeparam>
-    /// <param name="messages">The collection of messages to publish and process.</param>
-    /// <param name="onMessageReceived">
-    /// An asynchronous callback executed for each received message.
-    /// Supports cancellation via the provided <see cref="CancellationToken"/>.
-    /// </param>
-    /// <param name="onCompleted">
-    /// An optional callback executed after all messages have been processed.
-    /// <br/>
-    /// <ul>
-    /// <li><b>First parameter:</b> The number of processed messages.</li>
-    /// <li><b>Second parameter:</b> The number of messages that encountered errors.</li>
-    /// </ul>
-    /// </param>
-    /// <param name="options">Optional configuration settings for the temporary queue behavior.</param>
-    /// <param name="cancellationToken">
-    /// A token that can be used to cancel the overall operation early. This will cancel the consumption process and stop waiting for message completion.
-    /// <br/>
-    /// <b>When triggered, it will:</b>
-    /// <ul>
-    ///   <li>Abort waiting for all messages to be processed.</li>
-    ///   <li>Cancel any in-progress message handlers.</li>
-    ///   <li>Stop consuming further messages from the temporary queue.</li>
-    /// </ul>
-    /// This token is typically used to propagate shutdown signals or client-side timeouts.
-    /// <br/><br/>
-    /// <b>If no cancellation token is provided:</b>
-    /// <ul>
-    ///   <li>The process will continue running until all messages are processed from the queue.</li>
-    ///   <li>A per-message timeout (if configured via <see cref="RunTemporaryOptions.Timeout"/>) will still apply using an internal cancellation token for each message handler.</li>
-    /// </ul>
-    /// </param>
+    public interface IRabbitFlowTemporary
+    {
+        /// <summary>
+        /// Publishes a collection of messages to a temporary RabbitMQ exchange and consumes them asynchronously.
+        /// Each message is processed using the provided handler function, with support for cancellation and per-message timeout.
+        /// An optional completion callback can be invoked once all messages have been processed.
+        /// </summary>
+        /// <typeparam name="T">The type of messages to process. Must be a reference type.</typeparam>
+        /// <param name="messages">The collection of messages to publish and process.</param>
+        /// <param name="onMessageReceived">
+        /// An asynchronous callback executed for each received message.
+        /// Supports cancellation via the provided <see cref="CancellationToken"/>.
+        /// </param>
+        /// <param name="onCompleted">
+        /// An optional callback executed after all messages have been processed.
+        /// <br/>
+        /// <ul>
+        /// <li><b>First parameter:</b> The number of processed messages.</li>
+        /// <li><b>Second parameter:</b> The number of messages that encountered errors.</li>
+        /// </ul>
+        /// </param>
+        /// <param name="onError">
+        /// An optional asynchronous callback executed when a message fails during processing (due to timeout, cancellation, or exception).
+        /// Receives the failed message and a <see cref="CancellationToken"/>.
+        /// Use this to decide what to do with failed messages — e.g., log them, store them in a persistence layer, or republish to another queue.
+        /// <br/>
+        /// If not provided, errors are only logged internally.
+        /// </param>
+        /// <param name="options">Optional configuration settings for the temporary queue behavior.</param>
+        /// <param name="cancellationToken">
+        /// A token that can be used to cancel the overall operation early. This will cancel the consumption process and stop waiting for message completion.
+        /// <br/>
+        /// <b>When triggered, it will:</b>
+        /// <ul>
+        ///   <li>Abort waiting for all messages to be processed.</li>
+        ///   <li>Cancel any in-progress message handlers.</li>
+        ///   <li>Stop consuming further messages from the temporary queue.</li>
+        /// </ul>
+        /// This token is typically used to propagate shutdown signals or client-side timeouts.
+        /// <br/><br/>
+        /// <b>If no cancellation token is provided:</b>
+        /// <ul>
+        ///   <li>The process will continue running until all messages are processed from the queue.</li>
+        ///   <li>A per-message timeout (if configured via <see cref="RunTemporaryOptions.Timeout"/>) will still apply using an internal cancellation token for each message handler.</li>
+        /// </ul>
+        /// </param>
 
-    /// <returns>The number of successfully processed messages.</returns>
+        /// <returns>The number of successfully processed messages.</returns>
 
-    Task<int> RunAsync<T>(IReadOnlyList<T> messages, Func<T, CancellationToken, Task> onMessageReceived, Action<int, int>? onCompleted = null, RunTemporaryOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+        Task<int> RunAsync<T>(
+            IReadOnlyList<T> messages,
+            Func<T, CancellationToken, Task> onMessageReceived,
+            Action<int, int>? onCompleted = null,
+            Func<T, CancellationToken, Task>? onError = null,
+            RunTemporaryOptions? options = null,
+            CancellationToken cancellationToken = default) where T : class;
 
-    /// <summary>
-    /// Publishes a collection of messages to a temporary RabbitMQ queue and processes them asynchronously.
-    /// Each message is handled via a user-provided callback, and the results are safely collected into a concurrent queue.
-    /// </summary>
-    /// <typeparam name="T">The type of messages to be published. Must be a reference type.</typeparam>
-    /// <typeparam name="TResult">The type of result produced for each message.</typeparam>
-    /// <param name="messages">The list of messages to publish and process.</param>
-    /// <param name="onMessageReceived">
-    /// Asynchronous callback invoked for each received message.
-    /// Returns a result that will be added to the result queue.
-    /// </param>
-    /// <param name="onCompletedAsync">
-    /// Asynchronous callback executed once all messages have been processed.
-    /// <br/>
-    /// <ul>
-    /// <li><b>First parameter:</b> The total number of messages processed.</li>
-    /// <li><b>Second parameter:</b> A thread-safe queue containing the results of each message.</li>
-    /// </ul>
-    /// </param>
-    /// <param name="options">Optional configuration settings for the temporary queue behavior.</param>
-    /// <param name="cancellationToken">Token to cancel the operation prematurely.</param>
-    /// <returns>The total number of messages successfully processed.</returns>
-    Task<int> RunAsync<T, TResult>(
+        /// <summary>
+        /// Publishes a collection of messages to a temporary RabbitMQ queue and processes them asynchronously.
+        /// Each message is handled via a user-provided callback, and the results are safely collected into a concurrent queue.
+        /// </summary>
+        /// <typeparam name="T">The type of messages to be published. Must be a reference type.</typeparam>
+        /// <typeparam name="TResult">The type of result produced for each message.</typeparam>
+        /// <param name="messages">The list of messages to publish and process.</param>
+        /// <param name="onMessageReceived">
+        /// Asynchronous callback invoked for each received message.
+        /// Returns a result that will be added to the result queue.
+        /// </param>
+        /// <param name="onCompletedAsync">
+        /// Asynchronous callback executed once all messages have been processed.
+        /// <br/>
+        /// <ul>
+        /// <li><b>First parameter:</b> The total number of messages processed.</li>
+        /// <li><b>Second parameter:</b> A thread-safe queue containing the results of each message.</li>
+        /// </ul>
+        /// </param>
+        /// <param name="onError">
+        /// An optional asynchronous callback executed when a message fails during processing (due to timeout, cancellation, or exception).
+        /// Receives the failed message and a <see cref="CancellationToken"/>.
+        /// Use this to decide what to do with failed messages — e.g., log them, store them in a persistence layer, or republish to another queue.
+        /// <br/>
+        /// If not provided, errors are only logged internally.
+        /// </param>
+        /// <param name="options">Optional configuration settings for the temporary queue behavior.</param>
+        /// <param name="cancellationToken">Token to cancel the operation prematurely.</param>
+        /// <returns>The total number of messages successfully processed.</returns>
+        Task<int> RunAsync<T, TResult>(
         IReadOnlyList<T> messages,
         Func<T, CancellationToken, Task<TResult>> onMessageReceived,
         Func<int, ConcurrentQueue<TResult>, Task> onCompletedAsync,
+        Func<T, CancellationToken, Task>? onError = null,
         RunTemporaryOptions? options = null,
         CancellationToken cancellationToken = default) where T : class;
-}
-
-internal sealed class RabbitFlowTemporary : IRabbitFlowTemporary
-{
-    private readonly ConnectionFactory _connectionFactory;
-
-    private readonly ILogger<RabbitFlowTemporary> _logger;
-
-    public RabbitFlowTemporary(ConnectionFactory connectionFactory, ILogger<RabbitFlowTemporary> logger)
-    {
-        _connectionFactory = connectionFactory;
-
-        _logger = logger;
     }
 
-    public async Task<int> RunAsync<T>(
-        IReadOnlyList<T> messages,
-        Func<T, CancellationToken, Task> onMessageReceived,
-        Action<int, int>? onCompleted = null,
-        RunTemporaryOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    internal sealed class RabbitFlowTemporary : IRabbitFlowTemporary
     {
-        if (messages is null || messages.Count == 0)
+        private readonly ConnectionFactory _connectionFactory;
+
+        private readonly ILogger<RabbitFlowTemporary> _logger;
+
+        public RabbitFlowTemporary(ConnectionFactory connectionFactory, ILogger<RabbitFlowTemporary> logger)
         {
-            return 0;
+            _connectionFactory = connectionFactory;
+
+            _logger = logger;
         }
 
-        options ??= new RunTemporaryOptions();
-
-        var correlationId = options.CorrelationId;
-
-        var prefetchCount = options.PrefetchCount;
-
-        var timeout = options.Timeout;
-
-        var queuePrefixName = options.QueuePrefixName;
-
-        var executionId = Guid.NewGuid().ToString("N");
-
-        var eventName = typeof(T).Name.ToLower();
-
-        var _queue = $"{queuePrefixName ?? eventName}-temp-queue-{executionId}";
-
-        using var connection = await _connectionFactory.CreateConnectionAsync($"{_queue}", cancellationToken);
-
-        using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
-
-        var maxMessages = messages.Count;
-
-        await channel.QueueDeclareAsync(_queue, durable: false, exclusive: true, autoDelete: true, cancellationToken: cancellationToken);
-
-        await channel.BasicQosAsync(prefetchSize: 0, prefetchCount: prefetchCount, global: false, cancellationToken: cancellationToken);
-
-        var processed = 0;
-
-        var errors = 0;
-
-        var tcs = new TaskCompletionSource<bool>();
-
-        var consumer = new AsyncEventingBasicConsumer(channel);
-
-        var semaphore = new SemaphoreSlim(prefetchCount);
-
-        var channelGate = new SemaphoreSlim(1, 1);
-
-        var activeTasks = new ConcurrentBag<Task>();
-
-        consumer.ReceivedAsync += async (model, ea) =>
+        public async Task<int> RunAsync<T>(
+            IReadOnlyList<T> messages,
+            Func<T, CancellationToken, Task> onMessageReceived,
+            Action<int, int>? onCompleted = null,
+            Func<T, CancellationToken, Task>? onError = null,
+            RunTemporaryOptions? options = null,
+            CancellationToken cancellationToken = default) where T : class
         {
-            await semaphore.WaitAsync(cancellationToken);
-
-            var json = Encoding.UTF8.GetString(ea.Body.Span);
-
-            var message = JsonSerializer.Deserialize<T>(json, JsonSerializerOptions.Web);
-
-            if (message is null)
+            if (messages is null || messages.Count == 0)
             {
-                _logger.LogWarning("[RabbitFlowTemporary] Message is null. CorrelationId: {correlationId}", correlationId);
-                semaphore.Release();
-                return;
+                return 0;
             }
 
-            try
+            options ??= new RunTemporaryOptions();
+
+            var correlationId = options.CorrelationId;
+
+            var prefetchCount = options.PrefetchCount;
+
+            var timeout = options.Timeout;
+
+            var queuePrefixName = options.QueuePrefixName;
+
+            var executionId = Guid.NewGuid().ToString("N");
+
+            var eventName = typeof(T).Name.ToLower();
+
+            var _queue = $"{queuePrefixName ?? eventName}-temp-queue-{executionId}";
+
+            using var connection = await _connectionFactory.CreateConnectionAsync($"{_queue}", cancellationToken);
+
+            using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+            var maxMessages = messages.Count;
+
+            await channel.QueueDeclareAsync(_queue, durable: false, exclusive: true, autoDelete: true, cancellationToken: cancellationToken);
+
+            await channel.BasicQosAsync(prefetchSize: 0, prefetchCount: prefetchCount, global: false, cancellationToken: cancellationToken);
+
+            var processed = 0;
+
+            var errors = 0;
+
+            var tcs = new TaskCompletionSource<bool>();
+
+            var consumer = new AsyncEventingBasicConsumer(channel);
+
+            var semaphore = new SemaphoreSlim(prefetchCount);
+
+            var channelGate = new SemaphoreSlim(1, 1);
+
+            var activeTasks = new ConcurrentBag<Task>();
+
+            consumer.ReceivedAsync += async (model, ea) =>
             {
-                // Acknowledge the message to RabbitMQ
-                if (channel.IsOpen)
+                await semaphore.WaitAsync(cancellationToken);
+
+                var json = Encoding.UTF8.GetString(ea.Body.Span);
+
+                var message = JsonSerializer.Deserialize<T>(json, JsonSerializerOptions.Web);
+
+                if (message is null)
                 {
-                    await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
-                    }
-                    finally
-                    {
-                        channelGate.Release();
-                    }
+                    _logger.LogWarning("[RabbitFlowTemporary] Message is null. CorrelationId: {correlationId}", correlationId);
+                    semaphore.Release();
+                    return;
                 }
 
-                // Create the processing task that will manage its own semaphore release
-                var processingTask = Task.Run(async () =>
+                try
                 {
-                    try
+                    // Acknowledge the message to RabbitMQ
+                    if (channel.IsOpen)
                     {
-                        using var timeoutCts = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null;
-
-                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts?.Token ?? CancellationToken.None);
-
+                        await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                         try
                         {
-                            await onMessageReceived(message, linkedCts.Token).ConfigureAwait(false);
-                        }
-                        catch (TaskCanceledException) when (timeoutCts != null && timeoutCts.Token.IsCancellationRequested)
-                        {
-                            Interlocked.Increment(ref errors);
-                            _logger.LogError("[RabbitFlowTemporary] Message processing timed out after {Timeout}. CorrelationId: {correlationId}", timeout, correlationId);
-                        }
-                        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
-                        {
-                            Interlocked.Increment(ref errors);
-                            _logger.LogError("[RabbitFlowTemporary] Message processing was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
-                        }
-                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                        {
-                            Interlocked.Increment(ref errors);
-                            _logger.LogError("[RabbitFlowTemporary] Message processing was canceled. CorrelationId: {correlationId}", correlationId);
-                        }
-                        catch (Exception ex)
-                        {
-                            Interlocked.Increment(ref errors);
-                            _logger.LogError(ex, "[RabbitFlowTemporary] Error while processing the message. CorrelationId: {correlationId}", correlationId);
+                            await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
                         }
                         finally
                         {
-                            // Check if we're done with all messages
-                            if (Interlocked.Increment(ref processed) >= maxMessages && activeTasks.All(task => task.IsCompleted))
+                            channelGate.Release();
+                        }
+                    }
+
+                    // Create the processing task that will manage its own semaphore release
+                    var processingTask = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            using var timeoutCts = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null;
+
+                            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts?.Token ?? CancellationToken.None);
+
+                            try
+                            {
+                                await onMessageReceived(message, linkedCts.Token).ConfigureAwait(false);
+                            }
+                            catch (TaskCanceledException) when (timeoutCts != null && timeoutCts.Token.IsCancellationRequested)
+                            {
+                                Interlocked.Increment(ref errors);
+                                _logger.LogError("[RabbitFlowTemporary] Message processing timed out after {Timeout}. CorrelationId: {correlationId}", timeout, correlationId);
+                                await InvokeOnErrorAsync(onError, message, cancellationToken, _logger, correlationId);
+                            }
+                            catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+                            {
+                                Interlocked.Increment(ref errors);
+                                _logger.LogError("[RabbitFlowTemporary] Message processing was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, CancellationToken.None, _logger, correlationId);
+                            }
+                            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                            {
+                                Interlocked.Increment(ref errors);
+                                _logger.LogError("[RabbitFlowTemporary] Message processing was canceled. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, CancellationToken.None, _logger, correlationId);
+                            }
+                            catch (Exception ex)
+                            {
+                                Interlocked.Increment(ref errors);
+                                _logger.LogError(ex, "[RabbitFlowTemporary] Error while processing the message. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, cancellationToken, _logger, correlationId);
+                            }
+                            finally
+                            {
+                                // Check if we're done with all messages
+                                if (Interlocked.Increment(ref processed) >= maxMessages && activeTasks.All(task => task.IsCompleted))
+                                {
+                                    tcs.TrySetResult(true);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "[RabbitFlowTemporary] Unhandled exception in processing task. CorrelationId: {correlationId}", correlationId);
+
+                            if (Interlocked.Increment(ref processed) >= maxMessages)
                             {
                                 tcs.TrySetResult(true);
                             }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "[RabbitFlowTemporary] Unhandled exception in processing task. CorrelationId: {correlationId}", correlationId);
-
-                        if (Interlocked.Increment(ref processed) >= maxMessages)
-                        {
-                            tcs.TrySetResult(true);
-                        }
-                    }
-                    finally
-                    {
-                        // Always release the semaphore when the task is done
-                        semaphore.Release();
-                    }
-                });
-
-                activeTasks.Add(processingTask);
-            }
-            catch (Exception ex)
-            {
-                // Release semaphore on any error in the handler
-                semaphore.Release();
-
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error while preparing message processing. CorrelationId: {correlationId}", correlationId);
-
-                if (Interlocked.Increment(ref processed) >= maxMessages)
-                {
-                    tcs.TrySetResult(true);
-                }
-            }
-        };
-
-        var consumerTag = await channel.BasicConsumeAsync(_queue, autoAck: false, consumer);
-
-        foreach (var msg in messages)
-        {
-            try
-            {
-                var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(msg));
-
-                await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    await channel.BasicPublishAsync("", _queue, body);
-                }
-                finally
-                {
-                    channelGate.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                Interlocked.Increment(ref errors);
-
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error publishing message to exchange. CorrelationId: {correlationId}", correlationId);
-            }
-        }
-        var _ = Task.Run(async () =>
-         {
-             try
-             {
-                 while (!cancellationToken.IsCancellationRequested)
-                 {
-                     // If we've processed all messages and all tasks are complete
-                     if (processed >= maxMessages && (activeTasks.Count == 0 || activeTasks.All(t => t.IsCompleted)))
-                     {
-                         tcs.TrySetResult(true);
-                         break;
-                     }
-
-                     // Check periodically
-                     await Task.Delay(100, cancellationToken);
-                 }
-             }
-             catch (OperationCanceledException)
-             {
-                 // Ignore cancellation
-             }
-             catch (Exception ex)
-             {
-                 _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion monitoring task. CorrelationId: {correlationId}", correlationId);
-             }
-         }, cancellationToken);
-
-        using var ctr = cancellationToken.Register(() =>
-        {
-            tcs.TrySetCanceled(cancellationToken);
-        });
-
-        try
-        {
-            await tcs.Task.ConfigureAwait(false);
-        }
-        catch (TaskCanceledException)
-        {
-            _logger.LogError("[RabbitFlowTemporary] Task was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "[RabbitFlowTemporary] Error while waiting for messages to be processed. CorrelationId: {correlationId}", correlationId);
-        }
-        finally
-        {
-            try
-            {
-                await channel.BasicCancelAsync(consumerTag, cancellationToken: CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error canceling consumer. CorrelationId: {correlationId}", correlationId);
-            }
-
-            // Always run the completion callback
-            try
-            {
-                _logger.LogDebug("[RabbitFlowTemporary] Executing completion callback. Processed: {processed}, Errors: {errors}, CorrelationId: {correlationId}",
-                    processed, errors, correlationId);
-
-                onCompleted?.Invoke(processed, errors);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion callback. CorrelationId: {correlationId}", correlationId);
-            }
-
-            channelGate.Dispose();
-        }
-
-        return processed;
-    }
-
-    public async Task<int> RunAsync<T, TResult>(
-           IReadOnlyList<T> messages,
-           Func<T, CancellationToken, Task<TResult>> onMessageReceived,
-           Func<int, ConcurrentQueue<TResult>, Task> onCompletedAsync,
-           RunTemporaryOptions? options = null,
-           CancellationToken cancellationToken = default) where T : class
-    {
-        if (messages is null || messages.Count == 0)
-        {
-            return 0;
-        }
-
-        var resultsQueue = new ConcurrentQueue<TResult>();
-
-        options ??= new RunTemporaryOptions();
-
-        var correlationId = options.CorrelationId;
-
-        var prefetchCount = options.PrefetchCount;
-
-        var timeout = options.Timeout;
-
-        var queuePrefixName = options.QueuePrefixName;
-
-        var executionId = Guid.NewGuid().ToString("N");
-
-        var eventName = typeof(T).Name.ToLower();
-
-        var _queue = $"{queuePrefixName ?? eventName}-temp-queue-{executionId}";
-
-        using var connection = await _connectionFactory.CreateConnectionAsync($"{_queue}", cancellationToken);
-
-        using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
-
-        var maxMessages = messages.Count;
-
-        await channel.QueueDeclareAsync(_queue, durable: false, exclusive: true, autoDelete: true, cancellationToken: cancellationToken);
-
-        await channel.BasicQosAsync(prefetchSize: 0, prefetchCount: prefetchCount, global: false, cancellationToken: cancellationToken);
-
-        var processed = 0;
-
-        var tcs = new TaskCompletionSource<bool>();
-
-        var consumer = new AsyncEventingBasicConsumer(channel);
-
-        var semaphore = new SemaphoreSlim(prefetchCount);
-
-        var channelGate = new SemaphoreSlim(1, 1);
-
-        var activeTasks = new ConcurrentBag<Task>();
-
-        consumer.ReceivedAsync += async (model, ea) =>
-        {
-            await semaphore.WaitAsync(cancellationToken);
-
-            var json = Encoding.UTF8.GetString(ea.Body.Span);
-
-            var message = JsonSerializer.Deserialize<T>(json, JsonSerializerOptions.Web);
-
-            if (message is null)
-            {
-                _logger.LogWarning("[RabbitFlowTemporary] Message is null. CorrelationId: {correlationId}", correlationId);
-                semaphore.Release();
-                return;
-            }
-
-            try
-            {
-                // Acknowledge the message to RabbitMQ
-                if (channel.IsOpen)
-                {
-                    await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
-                    }
-                    finally
-                    {
-                        channelGate.Release();
-                    }
-                }
-
-                // Create the processing task that will manage its own semaphore release
-                var processingTask = Task.Run(async () =>
-                {
-                    try
-                    {
-                        using var timeoutCts = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null;
-                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts?.Token ?? CancellationToken.None);
-
-                        try
-                        {
-                            var result = await onMessageReceived(message, linkedCts.Token).ConfigureAwait(false);
-                            resultsQueue.Enqueue(result);
-                        }
-                        catch (TaskCanceledException) when (timeoutCts != null && timeoutCts.Token.IsCancellationRequested)
-                        {
-                            _logger.LogError("[RabbitFlowTemporary] Message processing timed out after {Timeout}. CorrelationId: {correlationId}", timeout, correlationId);
-                        }
-                        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
-                        {
-                            _logger.LogError("[RabbitFlowTemporary] Message processing was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
-                        }
-                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                        {
-                            _logger.LogError("[RabbitFlowTemporary] Message processing was canceled. CorrelationId: {correlationId}", correlationId);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "[RabbitFlowTemporary] Error while processing the message. CorrelationId: {correlationId}", correlationId);
-                        }
                         finally
                         {
-                            // Check if we're done with all messages
-                            if (Interlocked.Increment(ref processed) >= maxMessages && activeTasks.All(task => task.IsCompleted))
-                            {
-                                tcs.TrySetResult(true);
-                            }
+                            // Always release the semaphore when the task is done
+                            semaphore.Release();
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "[RabbitFlowTemporary] Unhandled exception in processing task. CorrelationId: {correlationId}", correlationId);
+                    });
 
-                        if (Interlocked.Increment(ref processed) >= maxMessages)
-                        {
-                            tcs.TrySetResult(true);
-                        }
-                    }
-                    finally
-                    {
-                        // Always release the semaphore when the task is done
-                        semaphore.Release();
-                    }
-                });
-
-                activeTasks.Add(processingTask);
-            }
-            catch (Exception ex)
-            {
-                // Release semaphore on any error in the handler
-                semaphore.Release();
-
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error while preparing message processing. CorrelationId: {correlationId}", correlationId);
-
-                if (Interlocked.Increment(ref processed) >= maxMessages)
-                {
-                    tcs.TrySetResult(true);
+                    activeTasks.Add(processingTask);
                 }
-            }
-        };
-
-        var consumerTag = await channel.BasicConsumeAsync(_queue, autoAck: false, consumer);
-
-        foreach (var msg in messages)
-        {
-            try
-            {
-                var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(msg, JsonSerializerOptions.Web));
-
-                await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
+                catch (Exception ex)
                 {
-                    await channel.BasicPublishAsync("", _queue, body);
-                }
-                finally
-                {
-                    channelGate.Release();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error publishing message to exchange. CorrelationId: {correlationId}", correlationId);
-            }
-        }
+                    // Release semaphore on any error in the handler
+                    semaphore.Release();
 
-        // After publishing all messages, start a monitoring task
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    // If we've processed all messages and all tasks are complete
-                    if (processed >= maxMessages && (activeTasks.Count == 0 || activeTasks.All(t => t.IsCompleted)))
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error while preparing message processing. CorrelationId: {correlationId}", correlationId);
+
+                    if (Interlocked.Increment(ref processed) >= maxMessages)
                     {
                         tcs.TrySetResult(true);
-                        break;
                     }
+                }
+            };
 
-                    // Check periodically
-                    await Task.Delay(100, cancellationToken);
+            var consumerTag = await channel.BasicConsumeAsync(_queue, autoAck: false, consumer);
+
+            foreach (var msg in messages)
+            {
+                try
+                {
+                    var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(msg));
+
+                    await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await channel.BasicPublishAsync("", _queue, body);
+                    }
+                    finally
+                    {
+                        channelGate.Release();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Interlocked.Increment(ref errors);
+
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error publishing message to exchange. CorrelationId: {correlationId}", correlationId);
                 }
             }
-            catch (OperationCanceledException)
-            {
-                // Ignore cancellation
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion monitoring task. CorrelationId: {correlationId}", correlationId);
-            }
-        }, cancellationToken);
+            var _ = Task.Run(async () =>
+             {
+                 try
+                 {
+                     while (!cancellationToken.IsCancellationRequested)
+                     {
+                         // If we've processed all messages and all tasks are complete
+                         if (processed >= maxMessages && (activeTasks.Count == 0 || activeTasks.All(t => t.IsCompleted)))
+                         {
+                             tcs.TrySetResult(true);
+                             break;
+                         }
 
-        try
-        {
-            await tcs.Task.ConfigureAwait(false);
-        }
-        catch (TaskCanceledException)
-        {
-            _logger.LogError("[RabbitFlowTemporary] Task was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "[RabbitFlowTemporary] Error while waiting for messages to be processed. CorrelationId: {correlationId}", correlationId);
-        }
-        finally
-        {
+                         // Check periodically
+                         await Task.Delay(100, cancellationToken);
+                     }
+                 }
+                 catch (OperationCanceledException)
+                 {
+                     // Ignore cancellation
+                 }
+                 catch (Exception ex)
+                 {
+                     _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion monitoring task. CorrelationId: {correlationId}", correlationId);
+                 }
+             }, cancellationToken);
+
+            using var ctr = cancellationToken.Register(() =>
+            {
+                tcs.TrySetCanceled(cancellationToken);
+            });
+
             try
             {
-                await channel.BasicCancelAsync(consumerTag, cancellationToken: CancellationToken.None);
+                await tcs.Task.ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                _logger.LogError("[RabbitFlowTemporary] Task was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error canceling consumer. CorrelationId: {correlationId}", correlationId);
+                _logger.LogError(ex, "[RabbitFlowTemporary] Error while waiting for messages to be processed. CorrelationId: {correlationId}", correlationId);
             }
-
-            // Always run the completion callback
-            try
+            finally
             {
-                _logger.LogDebug("[RabbitFlowTemporary] Executing async completion callback. Results: {count}, CorrelationId: {correlationId}", resultsQueue.Count, correlationId);
+                try
+                {
+                    await channel.BasicCancelAsync(consumerTag, cancellationToken: CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error canceling consumer. CorrelationId: {correlationId}", correlationId);
+                }
 
-                await onCompletedAsync(messages.Count, resultsQueue);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "[RabbitFlowTemporary] Error in async completion callback. CorrelationId: {correlationId}", correlationId);
+                // Always run the completion callback
+                try
+                {
+                    _logger.LogDebug("[RabbitFlowTemporary] Executing completion callback. Processed: {processed}, Errors: {errors}, CorrelationId: {correlationId}",
+                        processed, errors, correlationId);
+
+                    onCompleted?.Invoke(processed, errors);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion callback. CorrelationId: {correlationId}", correlationId);
+                }
+
+                channelGate.Dispose();
             }
 
-            channelGate.Dispose();
+            return processed;
         }
 
-        return processed;
+        public async Task<int> RunAsync<T, TResult>(
+               IReadOnlyList<T> messages,
+               Func<T, CancellationToken, Task<TResult>> onMessageReceived,
+               Func<int, ConcurrentQueue<TResult>, Task> onCompletedAsync,
+               Func<T, CancellationToken, Task>? onError = null,
+               RunTemporaryOptions? options = null,
+               CancellationToken cancellationToken = default) where T : class
+        {
+            if (messages is null || messages.Count == 0)
+            {
+                return 0;
+            }
+
+            var resultsQueue = new ConcurrentQueue<TResult>();
+
+            options ??= new RunTemporaryOptions();
+
+            var correlationId = options.CorrelationId;
+
+            var prefetchCount = options.PrefetchCount;
+
+            var timeout = options.Timeout;
+
+            var queuePrefixName = options.QueuePrefixName;
+
+            var executionId = Guid.NewGuid().ToString("N");
+
+            var eventName = typeof(T).Name.ToLower();
+
+            var _queue = $"{queuePrefixName ?? eventName}-temp-queue-{executionId}";
+
+            using var connection = await _connectionFactory.CreateConnectionAsync($"{_queue}", cancellationToken);
+
+            using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+            var maxMessages = messages.Count;
+
+            await channel.QueueDeclareAsync(_queue, durable: false, exclusive: true, autoDelete: true, cancellationToken: cancellationToken);
+
+            await channel.BasicQosAsync(prefetchSize: 0, prefetchCount: prefetchCount, global: false, cancellationToken: cancellationToken);
+
+            var processed = 0;
+
+            var tcs = new TaskCompletionSource<bool>();
+
+            var consumer = new AsyncEventingBasicConsumer(channel);
+
+            var semaphore = new SemaphoreSlim(prefetchCount);
+
+            var channelGate = new SemaphoreSlim(1, 1);
+
+            var activeTasks = new ConcurrentBag<Task>();
+
+            consumer.ReceivedAsync += async (model, ea) =>
+            {
+                await semaphore.WaitAsync(cancellationToken);
+
+                var json = Encoding.UTF8.GetString(ea.Body.Span);
+
+                var message = JsonSerializer.Deserialize<T>(json, JsonSerializerOptions.Web);
+
+                if (message is null)
+                {
+                    _logger.LogWarning("[RabbitFlowTemporary] Message is null. CorrelationId: {correlationId}", correlationId);
+                    semaphore.Release();
+                    return;
+                }
+
+                try
+                {
+                    // Acknowledge the message to RabbitMQ
+                    if (channel.IsOpen)
+                    {
+                        await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
+                        }
+                        finally
+                        {
+                            channelGate.Release();
+                        }
+                    }
+
+                    // Create the processing task that will manage its own semaphore release
+                    var processingTask = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            using var timeoutCts = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null;
+                            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts?.Token ?? CancellationToken.None);
+
+                            try
+                            {
+                                var result = await onMessageReceived(message, linkedCts.Token).ConfigureAwait(false);
+                                resultsQueue.Enqueue(result);
+                            }
+                            catch (TaskCanceledException) when (timeoutCts != null && timeoutCts.Token.IsCancellationRequested)
+                            {
+                                _logger.LogError("[RabbitFlowTemporary] Message processing timed out after {Timeout}. CorrelationId: {correlationId}", timeout, correlationId);
+                                await InvokeOnErrorAsync(onError, message, cancellationToken, _logger, correlationId);
+                            }
+                            catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+                            {
+                                _logger.LogError("[RabbitFlowTemporary] Message processing was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, CancellationToken.None, _logger, correlationId);
+                            }
+                            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                            {
+                                _logger.LogError("[RabbitFlowTemporary] Message processing was canceled. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, CancellationToken.None, _logger, correlationId);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "[RabbitFlowTemporary] Error while processing the message. CorrelationId: {correlationId}", correlationId);
+                                await InvokeOnErrorAsync(onError, message, cancellationToken, _logger, correlationId);
+                            }
+                            finally
+                            {
+                                // Check if we're done with all messages
+                                if (Interlocked.Increment(ref processed) >= maxMessages && activeTasks.All(task => task.IsCompleted))
+                                {
+                                    tcs.TrySetResult(true);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "[RabbitFlowTemporary] Unhandled exception in processing task. CorrelationId: {correlationId}", correlationId);
+
+                            if (Interlocked.Increment(ref processed) >= maxMessages)
+                            {
+                                tcs.TrySetResult(true);
+                            }
+                        }
+                        finally
+                        {
+                            // Always release the semaphore when the task is done
+                            semaphore.Release();
+                        }
+                    });
+
+                    activeTasks.Add(processingTask);
+                }
+                catch (Exception ex)
+                {
+                    // Release semaphore on any error in the handler
+                    semaphore.Release();
+
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error while preparing message processing. CorrelationId: {correlationId}", correlationId);
+
+                    if (Interlocked.Increment(ref processed) >= maxMessages)
+                    {
+                        tcs.TrySetResult(true);
+                    }
+                }
+            };
+
+            var consumerTag = await channel.BasicConsumeAsync(_queue, autoAck: false, consumer);
+
+            foreach (var msg in messages)
+            {
+                try
+                {
+                    var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(msg, JsonSerializerOptions.Web));
+
+                    await channelGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await channel.BasicPublishAsync("", _queue, body);
+                    }
+                    finally
+                    {
+                        channelGate.Release();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error publishing message to exchange. CorrelationId: {correlationId}", correlationId);
+                }
+            }
+
+            // After publishing all messages, start a monitoring task
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        // If we've processed all messages and all tasks are complete
+                        if (processed >= maxMessages && (activeTasks.Count == 0 || activeTasks.All(t => t.IsCompleted)))
+                        {
+                            tcs.TrySetResult(true);
+                            break;
+                        }
+
+                        // Check periodically
+                        await Task.Delay(100, cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore cancellation
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error in completion monitoring task. CorrelationId: {correlationId}", correlationId);
+                }
+            }, cancellationToken);
+
+            try
+            {
+                await tcs.Task.ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                _logger.LogError("[RabbitFlowTemporary] Task was canceled by main Cancellation Token. CorrelationId: {correlationId}", correlationId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[RabbitFlowTemporary] Error while waiting for messages to be processed. CorrelationId: {correlationId}", correlationId);
+            }
+            finally
+            {
+                try
+                {
+                    await channel.BasicCancelAsync(consumerTag, cancellationToken: CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error canceling consumer. CorrelationId: {correlationId}", correlationId);
+                }
+
+                // Always run the completion callback
+                try
+                {
+                    _logger.LogDebug("[RabbitFlowTemporary] Executing async completion callback. Results: {count}, CorrelationId: {correlationId}", resultsQueue.Count, correlationId);
+
+                    await onCompletedAsync(messages.Count, resultsQueue);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RabbitFlowTemporary] Error in async completion callback. CorrelationId: {correlationId}", correlationId);
+                }
+
+                channelGate.Dispose();
+            }
+
+            return processed;
+        }
+
+        private static async Task InvokeOnErrorAsync<T>(Func<T, CancellationToken, Task>? onError, T message, CancellationToken cancellationToken, ILogger logger, string? correlationId)
+        {
+            if (onError is null)
+            {
+                return;
+            }
+
+            try
+            {
+                await onError(message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "[RabbitFlowTemporary] Error in onError callback. CorrelationId: {correlationId}", correlationId);
+            }
+        }
+
     }
-
-}
 }

--- a/tests/EasyRabbitFlow.Tests/TemporaryTests.cs
+++ b/tests/EasyRabbitFlow.Tests/TemporaryTests.cs
@@ -150,4 +150,191 @@ public class TemporaryTests
         Assert.Equal(1, processed);
         Assert.Single(received);
     }
+
+    [Fact]
+    public async Task RunAsync_OnError_InvokedForFailedMessages()
+    {
+        // Arrange
+        var sp = _fixture.BuildServiceProvider();
+        var temporary = sp.GetRequiredService<IRabbitFlowTemporary>();
+
+        var messages = Enumerable.Range(1, 3)
+            .Select(i => new TestEvent { Id = i.ToString(), Message = $"msg-{i}" })
+            .ToList();
+
+        var failedMessages = new List<TestEvent>();
+
+        // Act – message with Id "2" throws
+        var processed = await temporary.RunAsync<TestEvent>(
+            messages,
+            async (msg, ct) =>
+            {
+                if (msg.Id == "2")
+                    throw new InvalidOperationException("Simulated failure");
+
+                await Task.CompletedTask;
+            },
+            onCompleted: (p, e) => { },
+            onError: async (msg, ct) =>
+            {
+                lock (failedMessages) { failedMessages.Add(msg); }
+                await Task.CompletedTask;
+            },
+            options: new RunTemporaryOptions { PrefetchCount = 1 });
+
+        // Assert
+        Assert.Equal(3, processed);
+        Assert.Single(failedMessages);
+        Assert.Equal("2", failedMessages[0].Id);
+    }
+
+    [Fact]
+    public async Task RunAsync_OnError_InvokedOnTimeout()
+    {
+        // Arrange
+        var sp = _fixture.BuildServiceProvider();
+        var temporary = sp.GetRequiredService<IRabbitFlowTemporary>();
+
+        var messages = new List<TestEvent>
+        {
+            new() { Id = "slow", Message = "will-timeout" }
+        };
+
+        var failedMessages = new List<TestEvent>();
+
+        // Act – handler exceeds the timeout
+        var processed = await temporary.RunAsync<TestEvent>(
+            messages,
+            async (msg, ct) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            },
+            onError: async (msg, ct) =>
+            {
+                lock (failedMessages) { failedMessages.Add(msg); }
+                await Task.CompletedTask;
+            },
+            options: new RunTemporaryOptions
+            {
+                Timeout = TimeSpan.FromMilliseconds(200),
+                PrefetchCount = 1
+            });
+
+        // Assert
+        Assert.Equal(1, processed);
+        Assert.Single(failedMessages);
+        Assert.Equal("slow", failedMessages[0].Id);
+    }
+
+    [Fact]
+    public async Task RunAsync_OnError_ReportsCorrectErrorCount()
+    {
+        // Arrange
+        var sp = _fixture.BuildServiceProvider();
+        var temporary = sp.GetRequiredService<IRabbitFlowTemporary>();
+
+        var messages = Enumerable.Range(1, 4)
+            .Select(i => new TestEvent { Id = i.ToString(), Message = $"msg-{i}" })
+            .ToList();
+
+        int completedTotal = 0;
+        int completedErrors = 0;
+        var failedMessages = new List<TestEvent>();
+
+        // Act – even-numbered messages fail
+        var processed = await temporary.RunAsync<TestEvent>(
+            messages,
+            async (msg, ct) =>
+            {
+                if (int.Parse(msg.Id) % 2 == 0)
+                    throw new Exception("Even fail");
+
+                await Task.CompletedTask;
+            },
+            onCompleted: (p, e) => { completedTotal = p; completedErrors = e; },
+            onError: async (msg, ct) =>
+            {
+                lock (failedMessages) 
+                { 
+                    failedMessages.Add(msg); 
+                }
+                await Task.CompletedTask;
+            },
+            options: new RunTemporaryOptions { PrefetchCount = 1 });
+
+        // Assert
+        Assert.Equal(4, processed);
+        Assert.Equal(4, completedTotal);
+        Assert.Equal(2, completedErrors);
+        Assert.Equal(2, failedMessages.Count);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithResults_OnError_InvokedForFailedMessages()
+    {
+        // Arrange
+        var sp = _fixture.BuildServiceProvider();
+        var temporary = sp.GetRequiredService<IRabbitFlowTemporary>();
+
+        var messages = Enumerable.Range(1, 3)
+            .Select(i => new TestEvent { Id = i.ToString(), Message = $"item-{i}" })
+            .ToList();
+
+        var collectedResults = new List<string>();
+        var failedMessages = new List<TestEvent>();
+
+        // Act – message with Id "2" throws
+        var processed = await temporary.RunAsync<TestEvent, string>(
+            messages,
+            async (msg, ct) =>
+            {
+                if (msg.Id == "2")
+                    throw new InvalidOperationException("Simulated failure");
+
+                await Task.CompletedTask;
+                return $"processed-{msg.Id}";
+            },
+            async (count, results) =>
+            {
+                collectedResults.AddRange(results);
+                await Task.CompletedTask;
+            },
+            onError: async (msg, ct) =>
+            {
+                lock (failedMessages) { failedMessages.Add(msg); }
+                await Task.CompletedTask;
+            },
+            options: new RunTemporaryOptions { PrefetchCount = 1 });
+
+        // Assert
+        Assert.Equal(3, processed);
+        Assert.Equal(2, collectedResults.Count);
+        Assert.Single(failedMessages);
+        Assert.Equal("2", failedMessages[0].Id);
+    }
+
+    [Fact]
+    public async Task RunAsync_OnError_NullCallback_DoesNotThrow()
+    {
+        // Arrange
+        var sp = _fixture.BuildServiceProvider();
+        var temporary = sp.GetRequiredService<IRabbitFlowTemporary>();
+
+        var messages = new List<TestEvent>
+        {
+            new() { Id = "1", Message = "will-fail" }
+        };
+
+        // Act – handler throws but no onError callback provided
+        var processed = await temporary.RunAsync<TestEvent>(
+            messages,
+            async (msg, ct) =>
+            {
+                throw new Exception("Boom");
+            },
+            options: new RunTemporaryOptions { PrefetchCount = 1 });
+
+        // Assert – should complete without throwing
+        Assert.Equal(1, processed);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `onError` callback to the temporary batch processing API, allowing custom handling of failed messages (due to exceptions, timeouts, or cancellations). The change is documented, implemented in the main service, and thoroughly tested. The update also bumps the package version to 5.1.0.

### Temporary Batch Processing Improvements

* Added `onError` callback support to `IRabbitFlowTemporary.RunAsync` methods, allowing users to handle failed messages (log, persist, republish, etc.) during batch processing. Errors in `onError` are caught and logged internally, so they do not disrupt processing. (`src/RabbitFlow/Services/IRabbitFlowTemporary.cs`, 
* Updated sample usage in `README.md` and `RabbitFlowSample/Program.cs` to demonstrate how to use the new `onError` callback for custom error handling.

### Testing

* Added comprehensive tests to verify that the `onError` callback is invoked for failed messages, timeouts, and correctly reports error counts. Also ensures that providing a null `onError` does not throw. (`tests/EasyRabbitFlow.Tests/TemporaryTests.cs`, [tests/EasyRabbitFlow.Tests/TemporaryTests.cs

### Versioning

* Updated package version to `5.1.0` to reflect the new feature addition. (`src/RabbitFlow/EasyRabbitFlow.csproj`, [src/RabbitFlow/EasyRabbitFlow.csproj