### PR TITLE
Breaking: Add dead-letter reprocessor and rework idempotency (v6)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,6 @@
 name: publish
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
-  push:
-    branches:
-      - 'master'       # Run the workflow when pushing to the main branch
-  pull_request:
-    branches:
-      - 'master'       # Run the workflow for pull requests targeting master
   release:
     types:
       - published    # Run the workflow when a new GitHub release is published
@@ -22,6 +16,15 @@ defaults:
     shell: pwsh
 
 jobs:
+  run_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Run tests
+      run: dotnet test --configuration Release
+
   create_nuget:
     runs-on: ubuntu-latest
     steps:
@@ -74,15 +77,6 @@ jobs:
       # using the --excluded-rules or --excluded-rule-ids option
       - name: Validate package
         run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg") --excluded-rule-ids 32,111,74,72,61
-
-  run_test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-    - name: Run tests
-      run: dotnet test --configuration Release
 
   deploy:
     # Publish only when creating a GitHub Release

--- a/EasyRabbitFlow.sln
+++ b/EasyRabbitFlow.sln
@@ -15,6 +15,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyRabbitFlow.Tests", "tests\EasyRabbitFlow.Tests\EasyRabbitFlow.Tests.csproj", "{C717CEF5-3120-4181-A990-694982FDEB9C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CBF5BAFC-127C-49AA-A58F-0DBBF797E2BF}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\main.yml = .github\workflows\main.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -16,38 +16,97 @@
 
 ---
 
+> ## ⚠️ Breaking Changes (v6.0.0)
+>
+>
+> **`PublisherOptions.IdempotencyEnabled` removed**
+>
+> Every published message now carries a `MessageId` unconditionally. The publisher no longer offers a knob to disable identification — it was a misnamed footgun (auto-GUID per call doesn't actually provide idempotency anyway, since retries get a new GUID).
+>
+> **Migration:** delete the line. Behavior is now what `IdempotencyEnabled = true` used to do.
+>
+> ```diff
+
+> cfg.ConfigurePublisher(pub =>
+> {
+>     pub.DisposePublisherConnection = false;
+> -   pub.IdempotencyEnabled = true;
+> });
+> ```
+
+>
+> **`PublishAsync` gained a `messageId` parameter; `PublishBatchAsync` gained a `messageIdSelector` parameter**
+>
+> For real publish-side idempotency (deterministic key derived from business data), pass the value yourself:
+>
+> ```csharp
+
+> // Single — caller supplies the key
+> await publisher.PublishAsync(order, "orders-queue", messageId: $"order-{order.Id}-created");
+>
+> // Batch — selector produces a key per event
+> await publisher.PublishBatchAsync(orders, "orders-queue", messageIdSelector: o => $"order-{o.Id}-created");
+> ```
+
+>
+> If you don't pass anything, you still get a unique GUID per message — same as before with `IdempotencyEnabled = true`.
+>
+> **`PublishResult.MessageId` is now `string` (non-nullable)**
+>
+> Always populated. If you had `if (result.MessageId != null) ...`, it's now dead code; just use `result.MessageId` directly.
+>
+> **Positional argument breakage**
+>
+> `PublishAsync` and `PublishBatchAsync` shifted parameters to insert `messageId` / `messageIdSelector` before `correlationId`. Callers using **named** arguments (`correlationId:`, `routingKey:`, etc.) are unaffected. Positional callers must update.
+>
+---
+>
+
 > ## ⚠️ Breaking Changes (v5.0.0)
+
+>
 >
 > **`IRabbitFlowConsumer<TEvent>.HandleAsync` signature changed**
 >
 > A new `RabbitFlowMessageContext` parameter was added to provide AMQP metadata (MessageId, CorrelationId, headers, delivery info) directly to each consumer.
 >
+>
 > ```diff
+
 > - Task HandleAsync(TEvent message, CancellationToken cancellationToken);
 > + Task HandleAsync(TEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken);
 > ```
+
 >
 > **How to migrate:** Add the `RabbitFlowMessageContext context` parameter to every `HandleAsync` implementation. If you don't need the context, simply ignore it:
 >
+>
 > ```csharp
+
 > public Task HandleAsync(MyEvent message, RabbitFlowMessageContext context, CancellationToken ct)
 > {
 >     // context is available but not required to use
 >     return ProcessAsync(message, ct);
 > }
 > ```
+
 >
 > **Other changes in v5.0.0:**
+>
+
 > - `PublishAsync` / `PublishBatchAsync` now accept an optional `correlationId` parameter.
+
+>
 > - `PublishAsync` returns `PublishResult` (instead of `bool`). Use `result.Success` instead of the raw return value.
 > - `PublishBatchAsync` is new — publish multiple messages atomically (`Transactional`) or individually confirmed (`Confirm`).
 > - `ChannelMode` was removed from `PublisherOptions` — it is now a per-call parameter on `PublishBatchAsync` (defaults to `Transactional`). Single-message publishes always use publisher confirms.
-> - `PublisherOptions.IdempotencyEnabled` is new — auto-assigns a unique `MessageId` to every published message.
+> - `PublisherOptions.IdempotencyEnabled` introduced (later removed in v6.0.0; `MessageId` is now always assigned).
 
 ---
 
 ## Table of Contents
 
+- [⚠️ Breaking Changes (v6.0.0)](#️-breaking-changes-v600)
 - [⚠️ Breaking Changes (v5.0.0)](#️-breaking-changes-v500)
 - [Why EasyRabbitFlow?](#why-easyrabbitflow)
 - [Architecture Overview](#architecture-overview)
@@ -65,6 +124,7 @@
   - [Retry Policies](#retry-policies)
   - [Consumer Timeout](#consumer-timeout)
   - [Custom Dead-Letter Queues](#custom-dead-letter-queues)
+  - [Dead-Letter Reprocessor](#dead-letter-reprocessor)
 - [Publishing Messages](#publishing-messages)
   - [Single Message](#single-message)
   - [Batch Publishing](#batch-publishing)
@@ -92,7 +152,7 @@
 | Queue state & purge utilities | ✅ |
 | Full DI integration (scoped/transient/singleton) | ✅ |
 | Publisher confirms (single) & transactional batch | ✅ |
-| Built-in idempotency support (auto `MessageId`) | ✅ |
+| Built-in `MessageId` on every message (auto-GUID or caller-supplied for true idempotency) | ✅ |
 | CorrelationId support (end-to-end tracing) | ✅ |
 | `RabbitFlowMessageContext` per-message metadata | ✅ |
 | Rich `PublishResult` / `BatchPublishResult` types | ✅ |
@@ -103,7 +163,7 @@
 
 ## Architecture Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │                         Your Application                            │
 ├────────────┬──────────────┬──────────────┬──────────────────────────┤
@@ -142,7 +202,7 @@
 
 ### Message Flow
 
-```
+```text
   Publisher                    RabbitMQ                        Consumer
   ────────                    ────────                        ────────
 
@@ -314,14 +374,14 @@ If not configured, the default `JsonSerializerOptions` are used.
 cfg.ConfigurePublisher(pub =>
 {
     pub.DisposePublisherConnection = false; // Keep connection alive (default)
-    pub.IdempotencyEnabled = true;          // Auto-assign MessageId to every message
 });
 ```
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `DisposePublisherConnection` | bool | `false` | Dispose connection after each publish |
-| `IdempotencyEnabled` | bool | `false` | Auto-assign a unique `MessageId` to every published message for deduplication |
+
+> Every published message always carries a `MessageId`. By default it is an auto-generated GUID; pass a deterministic key via the `messageId` parameter (single) or `messageIdSelector` (batch) when you need true idempotency from business data — see [Idempotency](#idempotency).
 
 ---
 
@@ -412,7 +472,7 @@ cfg.AddConsumer<OrderConsumer>("orders-queue", c =>
 
 **Generated topology when `AutoGenerate = true`:**
 
-```
+```text
                         ┌──────────────────────┐
                         │  orders-exchange      │
                         │  (fanout)             │
@@ -463,7 +523,7 @@ c.ConfigureRetryPolicy(r =>
 
 **Example: retry timeline with exponential backoff (factor=2, base=1000ms):**
 
-```
+```text
 Attempt 1 → fail → wait 1000ms
 Attempt 2 → fail → wait 2000ms
 Attempt 3 → fail → wait 4000ms
@@ -495,7 +555,7 @@ RabbitMQ also enforces its own per-queue delivery acknowledgement timeout (defau
 
 When `AutoGenerate = true`, EasyRabbitFlow automatically sets `x-consumer-timeout` on the declared queue to accommodate the full retry cycle plus a grace period:
 
-```
+```text
 x-consumer-timeout = Timeout × MaxRetryCount + Σ RetryIntervals + 30s grace
 ```
 
@@ -510,7 +570,11 @@ If the broker does close a channel (timeout exceeded, protocol violation, etc.),
 > Queue arguments are immutable in RabbitMQ. If you had a queue created by a previous version (without `x-consumer-timeout`), the next startup with `AutoGenerate = true` will fail with `PRECONDITION_FAILED: inequivalent arg 'x-consumer-timeout'`.
 >
 > **Options:**
+>
+
 > 1. Delete the queue and let EasyRabbitFlow recreate it.
+
+>
 > 2. Apply a [`consumer-timeout` policy](https://www.rabbitmq.com/docs/consumers#per-queue-delivery-timeout) to the existing queue on the broker and add `x-consumer-timeout` with the same value to `AutoGenerateSettings.Args` so the declare matches.
 > 3. Set `AutoGenerate = false` and manage the queue yourself (via policy on the broker).
 
@@ -531,14 +595,77 @@ When `ExtendDeadletterMessage = true`, the dead-letter message includes full err
 {
   "dateUtc": "2026-01-15T10:30:00Z",
   "messageType": "OrderCreatedEvent",
+  "messageId": "9f3...",
+  "correlationId": "req-abc-123",
   "messageData": { "orderId": "ORD-123", "total": 99.99 },
   "exceptionType": "TimeoutException",
   "errorMessage": "The operation was canceled.",
   "stackTrace": "...",
   "source": "OrderService",
-  "innerExceptions": []
+  "innerExceptions": [],
+  "reprocessAttempts": 0
 }
 ```
+
+The shape is exposed as the public type `DeadLetterEnvelope` so dead-letter messages can be deserialized with strong typing from any client.
+
+### Dead-Letter Reprocessor
+
+When in-handler retries are not enough — for example, when the failure is caused by a downstream system that takes hours to recover — you can attach a **dead-letter reprocessor** to a consumer. The reprocessor runs on a fixed cadence, drains the consumer's auto-generated dead-letter queue, and re-publishes each message to the main queue until a maximum attempt count is reached.
+
+```csharp
+cfg.AddConsumer<OrderConsumer>("orders-queue", c =>
+{
+    c.AutoGenerate = true;                       // required
+    c.ExtendDeadletterMessage = true;            // forced when reprocessor is enabled
+
+    c.ConfigureRetryPolicy(r => r.MaxRetryCount = 3);
+
+    c.ConfigureDeadLetterReprocess(r =>
+    {
+        r.Enabled = true;
+        r.MaxReprocessAttempts = 5;              // total times the message can be moved DLQ → main
+        r.Interval = TimeSpan.FromHours(3);      // run every 3 hours
+        // r.MaxMessagesPerCycle = 500;          // optional safety cap; defaults to int.MaxValue (drain entire snapshot)
+    });
+});
+```
+
+**Behavior:**
+
+```text
+                          ┌─ DLQ ─┐
+                          │       │
+                          │ env#1 │  ReprocessAttempts < Max → publish payload to main queue
+                          │ env#2 │   (with header x-reprocess-attempts incremented)
+                          │ env#3 │
+                          └───┬───┘
+                              │
+          ┌───────────────────┴───────────────────┐
+          │                                       │
+   Reprocessor cycle                       Main queue picks it up;
+   every `Interval`                        if it fails again, the new
+                                           envelope is written back
+                                           with the bumped counter
+                                           preserved via x-reprocess-attempts.
+```
+
+If a message exhausts its reprocess budget, the reprocessor re-publishes it back to the dead-letter queue (with `reprocessAttempts` reflecting the final count) so it remains visible in any RabbitMQ client and is not silently dropped.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Enabled` | bool | `true` | Whether the reprocessor is active for this consumer |
+| `MaxReprocessAttempts` | int | `3` | Maximum times a message is moved from DLQ back to main queue |
+| `Interval` | TimeSpan | `3h` | Time between reprocessor runs. **Minimum 10 minutes** (hard floor — use the in-handler `RetryPolicy` for tighter retry cadences) |
+| `MaxMessagesPerCycle` | int | `int.MaxValue` | Optional safety cap on messages drained per cycle. By default each cycle drains the whole DLQ snapshot taken at the start of the run; lower this only if you need an explicit ceiling. |
+
+**Constraints:**
+
+- Requires `AutoGenerate = true`. If the consumer manages its own topology, the reprocessor is silently disabled with a warning.
+- Forces `ExtendDeadletterMessage = true` so the envelope (including `reprocessAttempts`) is available — a warning is logged if you set it to `false`.
+- Operates only on the auto-generated dead-letter queue (`{queue}-deadletter`). Messages routed via `ConfigureCustomDeadletter` are not processed.
+- **Only transient failures are reprocessed.** A message is eligible only if its `exceptionType` in the envelope is `OperationCanceledException`, `TaskCanceledException`, or `RabbitFlowTransientException` — the same set the in-handler `RetryPolicy` retries. Permanent failures (validation, deserialization, business-rule violations) stay in the DLQ untouched so they remain visible for inspection.
+- Counter persistence: the reprocessor sets the AMQP header `x-reprocess-attempts` on every message it re-publishes. The consumer reads this header on receipt and seeds the new envelope with that count if processing fails again, so the counter survives the full cycle DLQ → main → DLQ.
 
 ---
 
@@ -604,7 +731,7 @@ Task<PublishResult> PublishAsync<TEvent>(TEvent message, string queueName,
 | Property | Type | Description |
 |----------|------|-------------|
 | `Success` | bool | Whether the broker confirmed the message |
-| `MessageId` | string? | Unique ID (when `IdempotencyEnabled = true`) |
+| `MessageId` | string | Identifier of the published message — caller-supplied via `messageId` parameter or auto-generated GUID. Always populated. |
 | `Destination` | string | Target exchange or queue name |
 | `RoutingKey` | string | Routing key used (empty for queue publishes) |
 | `TimestampUtc` | DateTime | When the publish was executed |
@@ -659,7 +786,7 @@ Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> message
 |----------|------|-------------|
 | `Success` | bool | Whether all messages were published |
 | `MessageCount` | int | Number of messages in the batch |
-| `MessageIds` | IReadOnlyList\<string\> | IDs per message (when `IdempotencyEnabled = true`) |
+| `MessageIds` | IReadOnlyList\<string\> | Identifiers per message (in input order) — produced by `messageIdSelector` when supplied or auto-generated GUIDs otherwise. Always one entry per published message. |
 | `Destination` | string | Target exchange or queue name |
 | `RoutingKey` | string | Routing key used |
 | `ChannelMode` | ChannelMode | Mode used (`Transactional` or `Confirm`) |
@@ -668,13 +795,48 @@ Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> message
 
 ### Idempotency
 
-Enable automatic `MessageId` generation so consumers can deduplicate:
+Every published message carries a `MessageId` set on `BasicProperties.MessageId` and returned in `PublishResult.MessageId` (or `BatchPublishResult.MessageIds`). There is no opt-out — identification is foundational, not optional.
+
+**Default — auto-generated unique GUID per call:**
 
 ```csharp
-cfg.ConfigurePublisher(pub => pub.IdempotencyEnabled = true);
+var result = await publisher.PublishAsync(order, "orders-queue");
+// result.MessageId == "f3a9c1d4..." (GUID, unique per call)
 ```
 
-When enabled, every published message (single or batch) gets a unique `MessageId` set in `BasicProperties.MessageId`. The ID is also returned in `PublishResult.MessageId` or `BatchPublishResult.MessageIds`.
+This is enough for tracing, logs, and per-attempt identification. It is **not** enough for true idempotency — retrying the same logical publish produces a different GUID each time, so consumers can't deduplicate against it.
+
+**True idempotency — caller-supplied deterministic key:**
+
+For dedup-friendly behavior, pass a `messageId` derived from your business data. Retries of the same logical event then carry the same `MessageId` and consumers can short-circuit duplicates.
+
+```csharp
+// Single message — derive the key from business data
+var result = await publisher.PublishAsync(
+    order,
+    "orders-queue",
+    messageId: $"order-{order.Id}-created");
+
+// Batch — selector produces a key per event
+var batchResult = await publisher.PublishBatchAsync(
+    orders,
+    "orders-queue",
+    messageIdSelector: o => $"order-{o.Id}-created");
+```
+
+The selector must return a non-empty string. Returning `null` or an empty string fails the batch (rolled back in `Transactional` mode, partially published in `Confirm` mode).
+
+On the consumer side, deduplicate using `RabbitFlowMessageContext.MessageId`:
+
+```csharp
+public async Task HandleAsync(OrderEvent message, RabbitFlowMessageContext context, CancellationToken ct)
+{
+    if (context.MessageId != null && await _seen.ContainsAsync(context.MessageId, ct))
+        return; // duplicate — already processed
+    await ProcessAsync(message, ct);
+    await _seen.AddAsync(context.MessageId!, ct);
+}
+```
 
 ### Correlation
 
@@ -720,6 +882,12 @@ public class OrderConsumer : IRabbitFlowConsumer<OrderCreatedEvent>
             _logger.LogWarning("Redelivered message, DeliveryTag={Tag}", context.DeliveryTag);
         }
 
+        // Detect messages re-enqueued by the dead-letter reprocessor
+        if (context.ReprocessAttempts > 0)
+        {
+            _logger.LogInformation("Reprocessing message (attempt {N}) after a previous failure.", context.ReprocessAttempts);
+        }
+
         await ProcessOrderAsync(message, ct);
     }
 }
@@ -729,13 +897,14 @@ public class OrderConsumer : IRabbitFlowConsumer<OrderCreatedEvent>
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `MessageId` | string? | Unique ID from `BasicProperties.MessageId` (set when `IdempotencyEnabled = true`) |
+| `MessageId` | string? | Identifier from `BasicProperties.MessageId`. Always populated for messages published via `IRabbitFlowPublisher` (caller-supplied or auto-GUID). May be `null` only for messages produced by third-party publishers that don't set it. |
 | `CorrelationId` | string? | Correlation ID from `BasicProperties.CorrelationId` (set via `correlationId` parameter) |
 | `Exchange` | string? | Exchange that delivered the message (empty for direct queue publishes) |
 | `RoutingKey` | string? | Routing key used when the message was published |
 | `Headers` | IDictionary? | Custom AMQP headers from `BasicProperties.Headers` |
 | `DeliveryTag` | ulong | Broker-assigned delivery tag for this message |
 | `Redelivered` | bool | Whether the broker redelivered this message |
+| `ReprocessAttempts` | int | Number of times this message was re-enqueued from the DLQ by the [Dead-Letter Reprocessor](#dead-letter-reprocessor). `0` for messages that have never been reprocessed. |
 
 > **Note:** `RabbitFlowMessageContext` is immutable — all properties are read-only and populated automatically from `BasicDeliverEventArgs` before `HandleAsync` is invoked.
 
@@ -796,6 +965,7 @@ await purger.PurgeMessagesAsync(new[] { "orders-queue", "emails-queue", "notific
 `IRabbitFlowTemporary` is designed for **fire-and-forget batch workflows** — process a collection of messages through RabbitMQ with automatic queue creation and cleanup.
 
 **Ideal for:**
+
 - Background jobs (PDF generation, email sending, report calculation)
 - One-time batch processing (database cleanup, data migration)
 - Parallel processing with configurable concurrency
@@ -891,7 +1061,7 @@ int processed = await _temporary.RunAsync<Invoice, InvoiceResult>(
 
 ### How It Works
 
-```
+```text
   Your Code                   RabbitMQ (Temporary)            Handler
   ─────────                   ──────────────────              ───────
 
@@ -921,7 +1091,23 @@ int processed = await _temporary.RunAsync<Invoice, InvoiceResult>(
 
 ## Transient Exceptions & Custom Retry Logic
 
-By default, timeouts and `RabbitFlowTransientException` trigger retries. Throw `RabbitFlowTransientException` from your consumer to signal a retryable error:
+EasyRabbitFlow distinguishes between **transient** failures (worth retrying) and **permanent** failures (drop straight to the dead-letter queue). The same set is honored by both the in-handler `RetryPolicy` and the [Dead-Letter Reprocessor](#dead-letter-reprocessor).
+
+### Exceptions auto-recognized as transient
+
+| Exception type | When it fires |
+|---|---|
+| `OperationCanceledException` | Per-attempt timeout (configured via `ConsumerSettings.Timeout`) |
+| `TaskCanceledException` | Same as above, plus most cooperative cancellations — including `HttpClient.Timeout` |
+| `RabbitFlowTransientException` | Explicitly thrown by your consumer to signal a retryable error |
+
+Anything else thrown by your handler is treated as **permanent** and routed to the dead-letter queue without further retry.
+
+> **HttpClient timeouts are covered for free.** When `HttpClient.SendAsync` times out it throws `TaskCanceledException`, which is already in the transient set — no wrapping needed.
+
+### Marking your own errors as transient
+
+If a failure is transient but doesn't fall into the auto-recognized set (a `429 Too Many Requests`, a `503`, a database deadlock…), catch the original exception and rethrow it wrapped in `RabbitFlowTransientException`:
 
 ```csharp
 using EasyRabbitFlow.Exceptions;
@@ -932,23 +1118,61 @@ public class PaymentConsumer : IRabbitFlowConsumer<PaymentEvent>
     {
         try
         {
-            await ProcessPaymentAsync(message);
+            await ProcessPaymentAsync(message, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            // This will trigger the retry policy
-            throw new RabbitFlowTransientException("Payment gateway temporarily unavailable", ex);
+            throw new RabbitFlowTransientException("Payment gateway temporarily unavailable (503).", ex);
         }
         // Any other exception → no retry, sent to dead-letter queue
     }
 }
 ```
 
-**Exception types:**
+**Example — making `429 Too Many Requests` transient:**
+
+A rate-limited downstream API responds with `429`. The failure is temporary by definition (waiting helps), so we want it retried by both the in-handler policy and, if the message ends up dead-lettered, by the reprocessor:
+
+```csharp
+using EasyRabbitFlow.Exceptions;
+
+public class NotificationConsumer : IRabbitFlowConsumer<NotificationEvent>
+{
+    private readonly HttpClient _http;
+
+    public NotificationConsumer(HttpClient http) => _http = http;
+
+    public async Task HandleAsync(NotificationEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.PostAsJsonAsync("https://api.example.com/notify", message, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Connection refused, DNS failure, socket reset… all worth retrying.
+            throw new RabbitFlowTransientException("Notification API unreachable.", ex);
+        }
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            // Mark 429 explicitly as transient so retry / reprocessor pick it up.
+            throw new RabbitFlowTransientException("Notification API rate-limited (429).");
+        }
+
+        response.EnsureSuccessStatusCode(); // 4xx (other than 429) bubbles up as permanent → DLQ
+    }
+}
+```
+
+**Why this matters for the reprocessor:** the reprocessor only re-enqueues messages whose recorded `exceptionType` is one of the three transient types listed above. Wrapping the right errors at the handler level is what makes them eligible for the slow recovery path provided by [`ConfigureDeadLetterReprocess`](#dead-letter-reprocessor).
+
+### Exception types reference
 
 | Exception | Purpose |
 |-----------|---------|
-| `RabbitFlowTransientException` | Signals a retryable error — triggers retry policy |
+| `RabbitFlowTransientException` | User-facing marker. Throw it from your handler to signal a retryable error to both the in-handler retry policy and the dead-letter reprocessor. |
 | `RabbitFlowException` | General library error |
 | `RabbitFlowOverRetriesException` | Thrown internally when all retry attempts are exhausted |
 
@@ -1019,7 +1243,6 @@ cfg.AddConsumer<MyConsumer>("high-volume-queue", c =>
 cfg.ConfigurePublisher(pub =>
 {
     pub.DisposePublisherConnection = false;         // Reuse connection
-    pub.IdempotencyEnabled = true;                  // Auto-assign MessageId
 });
 ```
 

--- a/sample/RabbitFlowSample/Consumers/WhatsAppConsumer.cs
+++ b/sample/RabbitFlowSample/Consumers/WhatsAppConsumer.cs
@@ -1,3 +1,4 @@
+using EasyRabbitFlow.Exceptions;
 using EasyRabbitFlow.Services;
 using EasyRabbitFlow.Settings;
 using RabbitFlowSample.Events;
@@ -19,11 +20,11 @@ public class WhatsAppConsumer(
 
         var transientGuid = guidTransientService.Guid;
 
-        logger.LogInformation("[WhatsApp] Singleton service GUID: {Guid}", singletonGuid);
+        //logger.LogInformation("[WhatsApp] Singleton service GUID: {Guid}", singletonGuid);
 
-        logger.LogInformation("[WhatsApp] Scoped service GUID: {Guid}", scopedGuid);
+        //logger.LogInformation("[WhatsApp] Scoped service GUID: {Guid}", scopedGuid);
 
-        logger.LogInformation("[WhatsApp] Transient service GUID: {Guid}", transientGuid);
+        //logger.LogInformation("[WhatsApp] Transient service GUID: {Guid}", transientGuid);
 
         if (message.WhatsAppNotificationData is null)
         {
@@ -31,10 +32,23 @@ public class WhatsAppConsumer(
             return;
         }
 
+        if (context.ReprocessAttempts > 0)
+        {
+            logger.LogInformation("Reprocessing message (attempt {N}) after a previous failure.", context.ReprocessAttempts);
+        }
+
+        var roll = Random.Shared.NextDouble();
+
+        if (roll < 0.5)
+        {
+            logger.LogWarning("[WhatsApp] Transient failure encountered. Will be retried if configured.");
+            throw new RabbitFlowTransientException("Simulated transient email send failure.");
+        }
+        
         var latency = Random.Shared.Next(50, 250);
         
-        await Task.Delay(latency, cancellationToken);
-        
+        await Task.Delay(latency, cancellationToken); // Simulate IO
+
         logger.LogInformation("[WhatsApp] Delivered whatsapp message after {Latency}ms: {Payload}", latency, JsonSerializer.Serialize(message.WhatsAppNotificationData));
     }
 }

--- a/sample/RabbitFlowSample/Program.cs
+++ b/sample/RabbitFlowSample/Program.cs
@@ -25,7 +25,6 @@ builder.Services.AddRabbitFlow(settings =>
     settings.ConfigurePublisher(publisherSettings =>
     {
         publisherSettings.DisposePublisherConnection = false;
-        publisherSettings.IdempotencyEnabled = true;
     }
     ); // OPTIONAL
 
@@ -37,7 +36,7 @@ builder.Services.AddRabbitFlow(settings =>
         consumerSettings.ConsumerId = "EmailQueueConsumer";
 
         consumerSettings.Timeout = TimeSpan.FromMilliseconds(1890000);
-        
+
         consumerSettings.AutoGenerate = true;
 
         consumerSettings.ConfigureAutoGenerate(opt =>
@@ -61,8 +60,8 @@ builder.Services.AddRabbitFlow(settings =>
 
     settings.AddConsumer<WhatsAppConsumer>(queueName: "whatsapp-queue", consumerSettings =>
     {
-        consumerSettings.Timeout = TimeSpan.FromMilliseconds(3000);
-        
+        consumerSettings.Timeout = TimeSpan.FromSeconds(60);
+
         consumerSettings.AutoGenerate = true;
 
         consumerSettings.ConfigureAutoGenerate(opt =>
@@ -72,7 +71,14 @@ builder.Services.AddRabbitFlow(settings =>
             opt.ExclusiveQueue = false;
         });
 
-        consumerSettings.ExtendDeadletterMessage = true;     
+        consumerSettings.ExtendDeadletterMessage = true;
+
+        consumerSettings.ConfigureDeadLetterReprocess(opt =>
+        {
+            opt.Enabled = true;
+            opt.MaxReprocessAttempts = 2;
+            opt.Interval = TimeSpan.FromHours(1);
+        });
     });
 
 
@@ -96,7 +102,7 @@ app.UseHttpsRedirection();
 // Fanout broadcast (both email & whatsapp consumers receive)
 app.MapPost("/notification", async ([FromServices] IRabbitFlowPublisher publisher, [FromBody] NotificationEvent eventPayload) =>
 {
-    var result = await publisher.PublishAsync(eventPayload, exchangeName: "notifications", routingKey: "");
+    var result = await publisher.PublishAsync(eventPayload, exchangeName: "notifications", routingKey: "", messageId: $"notification-{Guid.NewGuid()}");
 
     return result.Success
         ? Results.Accepted(value: new { result.MessageId, result.Destination, result.TimestampUtc, Payload = eventPayload })
@@ -135,7 +141,7 @@ app.MapPost("/whatsapp", async ([FromServices] IRabbitFlowPublisher publisher, [
 // Batch publish to fanout exchange (atomic by default - Transactional)
 app.MapPost("/notification/batch", async ([FromServices] IRabbitFlowPublisher publisher, [FromBody] NotificationEvent[] events) =>
 {
-    var result = await publisher.PublishBatchAsync(events, exchangeName: "notifications", routingKey: "");
+    var result = await publisher.PublishBatchAsync(events, exchangeName: "notifications", routingKey: "", messageIdSelector: e => $"notification-{Guid.NewGuid()}");
 
     return result.Success
         ? Results.Accepted(value: new { result.MessageCount, result.MessageIds, result.Destination, result.ChannelMode, result.TimestampUtc })
@@ -146,16 +152,16 @@ app.MapPost("/notification/batch", async ([FromServices] IRabbitFlowPublisher pu
 .Produces(StatusCodes.Status202Accepted);
 
 
-app.MapPost("/volatile", async (int count, [FromServices] IRabbitFlowTemporary rabbitFlowTemporary, ILogger<Program> logger,  CancellationToken ct) =>
+app.MapPost("/volatile", async (int count, [FromServices] IRabbitFlowTemporary rabbitFlowTemporary, ILogger<Program> logger, CancellationToken ct) =>
 {
     var events = Enumerable.Range(0, count).Select(_ => new VolatileEvent()).ToArray();
-    
+
     var processed = await rabbitFlowTemporary.RunAsync(
         messages: events,
         onMessageReceived: async (@event, msgCt) =>
         {
             await Task.Delay(TimeSpan.FromMilliseconds(250), msgCt);
-            throw new Exception("Simulated processing error");
+          
             logger.LogInformation("Processed volatile event {Id}", @event.Id);
         },
         onCompleted: (totalProcessed, errors) =>
@@ -181,7 +187,7 @@ app.MapPost("/volatile", async (int count, [FromServices] IRabbitFlowTemporary r
 .Produces(StatusCodes.Status200OK);
 
 
-app.MapPost("/volatile-fire-and-forget", async (int count, [FromServices] IRabbitFlowTemporary rabbitFlowTemporary, ILogger<Program> logger,  CancellationToken ct = default) =>
+app.MapPost("/volatile-fire-and-forget", async (int count, [FromServices] IRabbitFlowTemporary rabbitFlowTemporary, ILogger<Program> logger, CancellationToken ct = default) =>
 {
     var events = Enumerable.Range(0, count).Select(_ => new VolatileEvent()).ToArray();
 

--- a/src/RabbitFlow/ConsumerRegistration.cs
+++ b/src/RabbitFlow/ConsumerRegistration.cs
@@ -305,7 +305,8 @@ namespace EasyRabbitFlow
                                 args.RoutingKey,
                                 args.BasicProperties?.Headers,
                                 args.DeliveryTag,
-                                args.Redelivered);
+                                args.Redelivered,
+                                RabbitFlowHeaders.ReadReprocessAttempts(args.BasicProperties?.Headers));
 
                             consumerService = scope.ServiceProvider.GetRequiredService<TConsumer>();
 

--- a/src/RabbitFlow/DependencyInjection.cs
+++ b/src/RabbitFlow/DependencyInjection.cs
@@ -61,6 +61,8 @@ namespace EasyRabbitFlow
         {
             services.AddHostedService<ConsumerHostedService>();
 
+            services.AddHostedService<DeadLetterReprocessorHostedService>();
+
             return services;
         }
     }

--- a/src/RabbitFlow/EasyRabbitFlow.csproj
+++ b/src/RabbitFlow/EasyRabbitFlow.csproj
@@ -6,7 +6,7 @@
 		<Title>EasyRabbitFlow</Title>
 		<Authors>Juan Carlos Torres Cuervo</Authors>
 		<Description>EasyRabbitFlow: high-performance RabbitMQ client for .NET. Fluent configuration, optional topology (queue/exchange/dead-letter) generation, reflection-free consumers, configurable retry (exponential/backoff), custom dead-letter routing, temporary batch processing, queue state helpers. Targets .NET Standard 2.1.</Description>
-		<Version>5.1.1</Version>
+		<Version>6.0.0</Version>
 		<PackageTags>rabbitmq;dotnet;messaging;queue;consumer;publisher;retry;deadletter;backoff;temporary;batch</PackageTags>
 		<PackageProjectUrl>https://github.com/devjuanca/EasyRabbitFlow</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/devjuanca/EasyRabbitFlow</RepositoryUrl>

--- a/src/RabbitFlow/Services/ConsumerHostedService.cs
+++ b/src/RabbitFlow/Services/ConsumerHostedService.cs
@@ -142,8 +142,26 @@ namespace EasyRabbitFlow.Services
             _timeout = settings.Timeout;
             _prefetch = settings.PrefetchCount;
             _autoGenerate = settings.AutoGenerate;
-            _extendDeadLetter = settings.ExtendDeadletterMessage;
             _autoAckOnError = settings.AutoAckOnError;
+
+            var reprocessObj = root.GetService(typeof(DeadLetterReprocessSettings<>).MakeGenericType(_consumerType));
+
+            var reprocessConfigured = reprocessObj != null
+                && (bool)reprocessObj.GetType().GetProperty(nameof(DeadLetterReprocessSettings<object>.Enabled))!.GetValue(reprocessObj)!;
+
+            var effectiveExtend = settings.ExtendDeadletterMessage;
+
+            if (reprocessConfigured && !_autoGenerate)
+            {
+                logger.LogWarning("[RABBIT-FLOW]: Dead-letter reprocessor configured for {Consumer} but AutoGenerate is disabled. Reprocessor will be ignored.", _consumerType.Name);
+            }
+            else if (reprocessConfigured && _autoGenerate && !effectiveExtend)
+            {
+                logger.LogWarning("[RABBIT-FLOW]: Dead-letter reprocessor enabled for {Consumer}; forcing ExtendDeadletterMessage = true.", _consumerType.Name);
+                effectiveExtend = true;
+            }
+
+            _extendDeadLetter = effectiveExtend;
 
             var retryPolicyObj = root.GetService(typeof(RetryPolicy<>).MakeGenericType(_consumerType))
                                 ?? Activator.CreateInstance(typeof(RetryPolicy<>).MakeGenericType(_consumerType));
@@ -344,6 +362,10 @@ namespace EasyRabbitFlow.Services
 
                 var body = args.Body.ToArray();
 
+                var reprocessAttempts = RabbitFlowHeaders.ReadReprocessAttempts(args.BasicProperties?.Headers);
+                var msgId = args.BasicProperties?.MessageId;
+                var corrId = args.BasicProperties?.CorrelationId;
+
                 object? evt;
                 try
                 {
@@ -351,7 +373,7 @@ namespace EasyRabbitFlow.Services
                 }
                 catch (Exception ex)
                 {
-                    await HandleErrorAsync(channel, args.DeliveryTag, null, ex, rootCt);
+                    await HandleErrorAsync(channel, args.DeliveryTag, null, body, reprocessAttempts, msgId, corrId, ex, rootCt);
                     return;
                 }
 
@@ -375,7 +397,8 @@ namespace EasyRabbitFlow.Services
                             args.RoutingKey,
                             args.BasicProperties?.Headers,
                             args.DeliveryTag,
-                            args.Redelivered);
+                            args.Redelivered,
+                            reprocessAttempts);
 
                         var consumerInstance = scope.ServiceProvider.GetRequiredService(_consumerType);
 
@@ -408,7 +431,7 @@ namespace EasyRabbitFlow.Services
 
                 if (remainingAttempts <= 0)
                 {
-                    await HandleErrorAsync(channel, args.DeliveryTag, evt, lastException ?? new Exception("Unknown error"), rootCt);
+                    await HandleErrorAsync(channel, args.DeliveryTag, evt, body, reprocessAttempts, msgId, corrId, lastException ?? new Exception("Unknown error"), rootCt);
 
                     if (_customDeadLetterObj != null && evt != null)
                     {
@@ -470,7 +493,7 @@ namespace EasyRabbitFlow.Services
             finally { _channelGate.Release(); }
         }
 
-        private async Task HandleErrorAsync(IChannel channel, ulong deliveryTag, object? evt, Exception exception, CancellationToken ct)
+        private async Task HandleErrorAsync(IChannel channel, ulong deliveryTag, object? evt, byte[]? body, int reprocessAttempts, string? messageId, string? correlationId, Exception exception, CancellationToken ct)
         {
             await _channelGate.WaitAsync(ct).ConfigureAwait(false);
             try
@@ -483,7 +506,20 @@ namespace EasyRabbitFlow.Services
 
                 if (_extendDeadLetter && !string.IsNullOrEmpty(_deadLetterQueueName))
                 {
-                    var innerExceptions = new List<object>();
+                    var envelope = new DeadLetterEnvelope
+                    {
+                        DateUtc = DateTime.UtcNow,
+                        MessageType = _eventType.Name,
+                        MessageId = messageId,
+                        CorrelationId = correlationId,
+                        MessageData = TryParseJsonElement(body),
+                        ExceptionType = exception?.GetType().Name,
+                        ErrorMessage = exception?.Message,
+                        StackTrace = exception?.StackTrace,
+                        Source = exception?.Source,
+                        ReprocessAttempts = reprocessAttempts
+                    };
+
                     const int MaxDepth = 10;
                     var temp = exception;
                     var depth = 0;
@@ -493,26 +529,20 @@ namespace EasyRabbitFlow.Services
                         temp = temp.InnerException;
                         if (temp != null)
                         {
-                            innerExceptions.Add(new { exceptionType = temp.GetType().Name, errorMessage = temp.Message, stackTrace = temp.StackTrace, source = temp.Source });
+                            envelope.InnerExceptions.Add(new DeadLetterInnerException
+                            {
+                                ExceptionType = temp.GetType().Name,
+                                ErrorMessage = temp.Message,
+                                StackTrace = temp.StackTrace,
+                                Source = temp.Source
+                            });
                         }
                         depth++;
                     }
 
-                    var extendedMessage = new
-                    {
-                        dateUtc = DateTime.UtcNow,
-                        messageType = _eventType.Name,
-                        messageData = evt,
-                        exceptionType = exception?.GetType().Name,
-                        errorMessage = exception?.Message,
-                        stackTrace = exception?.StackTrace,
-                        source = exception?.Source,
-                        innerExceptions
-                    };
-
                     try
                     {
-                        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(extendedMessage, _serializerOptions));
+                        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, _serializerOptions));
                         await channel.BasicPublishAsync(exchange: "", routingKey: _deadLetterQueueName, body: bytes, cancellationToken: ct);
                         await channel.BasicAckAsync(deliveryTag, false, ct);
                     }
@@ -655,6 +685,21 @@ namespace EasyRabbitFlow.Services
             catch { }
 
             try { conn.Dispose(); } catch { }
+        }
+
+        private static JsonElement? TryParseJsonElement(byte[]? body)
+        {
+            if (body == null || body.Length == 0) return null;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                return doc.RootElement.Clone();
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/RabbitFlow/Services/DeadLetterReprocessorHostedService.cs
+++ b/src/RabbitFlow/Services/DeadLetterReprocessorHostedService.cs
@@ -1,0 +1,343 @@
+using EasyRabbitFlow.Exceptions;
+using EasyRabbitFlow.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyRabbitFlow.Services
+{
+    /// <summary>
+    /// Hosted service that periodically drains the auto-generated dead-letter queue of every consumer
+    /// configured with <see cref="DeadLetterReprocessSettings{TConsumer}"/> and re-publishes messages
+    /// back to the main queue until the configured maximum attempt count is reached.
+    /// </summary>
+    internal sealed class DeadLetterReprocessorHostedService : IHostedService
+    {
+        private readonly IServiceProvider _root;
+        private readonly ILogger<DeadLetterReprocessorHostedService> _logger;
+        private readonly List<DeadLetterReprocessWorker> _workers = new List<DeadLetterReprocessWorker>();
+        private CancellationTokenSource? _stoppingCts;
+
+        public DeadLetterReprocessorHostedService(IServiceProvider root, ILogger<DeadLetterReprocessorHostedService> logger)
+        {
+            _root = root;
+            _logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            var markers = _root.GetServices<IConsumerSettingsMarker>().ToList();
+
+            if (markers.Count == 0) 
+                return Task.CompletedTask;
+
+            _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var connectionFactory = _root.GetRequiredService<ConnectionFactory>();
+
+            var serializerOptions = _root.GetKeyedService<JsonSerializerOptions>("RabbitFlowJsonSerializer") ?? new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            foreach (var marker in markers)
+            {
+                var settings = marker.SettingsInstance;
+
+                if (!settings.Enable) continue;
+
+                if (!settings.AutoGenerate) continue;
+
+                if (string.IsNullOrWhiteSpace(settings.QueueName)) continue;
+
+                var reprocessObj = _root.GetService(typeof(DeadLetterReprocessSettings<>).MakeGenericType(marker.ConsumerType));
+
+                if (reprocessObj == null) continue;
+
+                var rpType = reprocessObj.GetType();
+
+                var enabled = (bool)rpType.GetProperty(nameof(DeadLetterReprocessSettings<object>.Enabled))!.GetValue(reprocessObj)!;
+
+                if (!enabled) continue;
+
+                var maxAttempts = (int)rpType.GetProperty(nameof(DeadLetterReprocessSettings<object>.MaxReprocessAttempts))!.GetValue(reprocessObj)!;
+                var interval = (TimeSpan)rpType.GetProperty(nameof(DeadLetterReprocessSettings<object>.Interval))!.GetValue(reprocessObj)!;
+                var maxMessagesPerCycle = (int)rpType.GetProperty(nameof(DeadLetterReprocessSettings<object>.MaxMessagesPerCycle))!.GetValue(reprocessObj)!;
+
+                var worker = new DeadLetterReprocessWorker(
+                    _logger,
+                    connectionFactory,
+                    serializerOptions,
+                    consumerName: marker.ConsumerType.Name,
+                    queueName: settings.QueueName,
+                    maxAttempts: maxAttempts,
+                    interval: interval,
+                    maxMessagesPerCycle: maxMessagesPerCycle);
+
+                _workers.Add(worker);
+
+                worker.Start(_stoppingCts.Token);
+
+                _logger.LogInformation("[RABBIT-FLOW]: Dead-letter reprocessor enabled for {Consumer}. Queue={Queue}, Interval={Interval}, MaxAttempts={MaxAttempts}, MaxMessagesPerCycle={MaxPerCycle}",
+                    marker.ConsumerType.Name, settings.QueueName, interval, maxAttempts, maxMessagesPerCycle);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_stoppingCts != null)
+            {
+                try { _stoppingCts.Cancel(); } catch { }
+            }
+
+            foreach (var worker in _workers)
+            {
+                await worker.WaitForCompletionAsync();
+            }
+
+            _stoppingCts?.Dispose();
+        }
+    }
+
+    internal sealed class DeadLetterReprocessWorker
+    {
+        private readonly ILogger _logger;
+        private readonly ConnectionFactory _connectionFactory;
+        private readonly JsonSerializerOptions _serializerOptions;
+        private readonly string _consumerName;
+        private readonly string _queueName;
+        private readonly string _deadLetterQueueName;
+        private readonly int _maxAttempts;
+        private readonly TimeSpan _interval;
+        private readonly int _maxMessagesPerCycle;
+
+        private Task? _runTask;
+
+        public DeadLetterReprocessWorker(
+            ILogger logger,
+            ConnectionFactory connectionFactory,
+            JsonSerializerOptions serializerOptions,
+            string consumerName,
+            string queueName,
+            int maxAttempts,
+            TimeSpan interval,
+            int maxMessagesPerCycle)
+        {
+            _logger = logger;
+            _connectionFactory = connectionFactory;
+            _serializerOptions = serializerOptions;
+            _consumerName = consumerName;
+            _queueName = queueName;
+            _deadLetterQueueName = $"{queueName}-deadletter";
+            _maxAttempts = maxAttempts;
+            _interval = interval;
+            _maxMessagesPerCycle = maxMessagesPerCycle;
+        }
+
+        public void Start(CancellationToken cancellationToken)
+        {
+            _runTask = Task.Run(() => RunAsync(cancellationToken), cancellationToken);
+        }
+
+        public Task WaitForCompletionAsync() => _runTask ?? Task.CompletedTask;
+
+        private async Task RunAsync(CancellationToken ct)
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    try 
+                    { 
+                        await Task.Delay(_interval, ct).ConfigureAwait(false); 
+                    }
+                    catch (OperationCanceledException) 
+                    { 
+                        return; 
+                    }
+
+                    try
+                    {
+                        await RunCycleAsync(ct).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested) 
+                    { 
+                        return; 
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[RABBIT-FLOW]: Dead-letter reprocessor cycle failed for {Consumer}.", _consumerName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[RABBIT-FLOW]: Dead-letter reprocessor worker crashed for {Consumer}.", _consumerName);
+            }
+        }
+
+        private async Task RunCycleAsync(CancellationToken ct)
+        {
+            using var connection = await _connectionFactory.CreateConnectionAsync($"reprocessor_{_queueName}", ct).ConfigureAwait(false);
+            
+            using var channel = await connection.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+
+            uint initialCount;
+
+            try
+            {
+                initialCount = await channel.MessageCountAsync(_deadLetterQueueName, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[RABBIT-FLOW]: Reprocessor could not read DLQ length for {Dlq}. Skipping cycle.", _deadLetterQueueName);
+                return;
+            }
+
+            if (initialCount == 0)
+            {
+                _logger.LogDebug("[RABBIT-FLOW]: Reprocessor for {Consumer}: DLQ {Dlq} is empty.", _consumerName, _deadLetterQueueName);
+                return;
+            }
+
+            var toProcess = (int)Math.Min(initialCount, (uint)_maxMessagesPerCycle);
+
+            int reenqueued = 0, exhausted = 0, malformed = 0, permanent = 0;
+
+            for (int i = 0; i < toProcess && !ct.IsCancellationRequested; i++)
+            {
+                BasicGetResult? result;
+
+                try
+                {
+                    result = await channel.BasicGetAsync(_deadLetterQueueName, autoAck: false, ct).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[RABBIT-FLOW]: BasicGet failed on {Dlq}; aborting cycle.", _deadLetterQueueName);
+                    break;
+                }
+
+                if (result == null) 
+                    break;
+
+                DeadLetterEnvelope? envelope = null;
+
+                try
+                {
+                    envelope = JsonSerializer.Deserialize<DeadLetterEnvelope>(result.Body.Span, _serializerOptions);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "[RABBIT-FLOW]: Failed to deserialize dead-letter envelope from {Dlq}.", _deadLetterQueueName);
+                }
+
+                if (envelope == null || !envelope.MessageData.HasValue)
+                {
+                    malformed++;
+                    
+                    await RepublishUnchangedAsync(channel, result, ct).ConfigureAwait(false);
+                    
+                    continue;
+                }
+
+                if (!IsTransientException(envelope.ExceptionType))
+                {
+                    permanent++;
+                    _logger.LogDebug("[RABBIT-FLOW]: Reprocessor for {Consumer} skipping permanent failure ({ExceptionType}) in {Dlq}.",
+                        _consumerName, envelope.ExceptionType ?? "(unknown)", _deadLetterQueueName);
+                    
+                    await RepublishUnchangedAsync(channel, result, ct).ConfigureAwait(false);
+                    
+                    continue;
+                }
+
+                if (envelope.ReprocessAttempts < _maxAttempts)
+                {
+                    var newAttempts = envelope.ReprocessAttempts + 1;
+
+                    var payload = Encoding.UTF8.GetBytes(envelope.MessageData.Value.GetRawText());
+
+                    var props = new BasicProperties
+                    {
+                        MessageId = envelope.MessageId,
+                        CorrelationId = envelope.CorrelationId,
+                        Headers = new Dictionary<string, object?>
+                        {
+                            [RabbitFlowHeaders.ReprocessAttempts] = newAttempts
+                        }
+                    };
+
+                    try
+                    {
+                        await channel.BasicPublishAsync(exchange: "", routingKey: _queueName, mandatory: false, basicProperties: props, body: payload, cancellationToken: ct).ConfigureAwait(false);
+                        
+                        await channel.BasicAckAsync(result.DeliveryTag, false, ct).ConfigureAwait(false);
+                        
+                        reenqueued++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[RABBIT-FLOW]: Failed to re-enqueue message to {Queue}; aborting cycle.", _queueName);
+                        break;
+                    }
+                }
+                else
+                {
+                    envelope.ReprocessAttempts = _maxAttempts;
+
+                    try
+                    {
+                        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, _serializerOptions));
+                        
+                        await channel.BasicPublishAsync(exchange: "", routingKey: _deadLetterQueueName, body: bytes, cancellationToken: ct).ConfigureAwait(false);
+                        
+                        await channel.BasicAckAsync(result.DeliveryTag, false, ct).ConfigureAwait(false);
+                        
+                        exhausted++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[RABBIT-FLOW]: Failed to re-publish exhausted message to {Dlq}.", _deadLetterQueueName);
+                        break;
+                    }
+                }
+            }
+
+            _logger.LogInformation("[RABBIT-FLOW]: Reprocessor cycle for {Consumer} done. Reenqueued={Reenqueued}, Exhausted={Exhausted}, Permanent={Permanent}, Malformed={Malformed}.",
+                _consumerName, reenqueued, exhausted, permanent, malformed);
+        }
+
+        private static bool IsTransientException(string? exceptionType)
+        {
+            if (string.IsNullOrEmpty(exceptionType)) return false;
+
+            return exceptionType == nameof(OperationCanceledException)
+                || exceptionType == nameof(TaskCanceledException)
+                || exceptionType == nameof(RabbitFlowTransientException);
+        }
+
+        private async Task RepublishUnchangedAsync(IChannel channel, BasicGetResult result, CancellationToken ct)
+        {
+            try
+            {
+                await channel.BasicPublishAsync(exchange: "", routingKey: _deadLetterQueueName, body: result.Body, cancellationToken: ct).ConfigureAwait(false);
+                await channel.BasicAckAsync(result.DeliveryTag, false, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[RABBIT-FLOW]: Failed to re-publish malformed message to {Dlq}.", _deadLetterQueueName);
+            }
+        }
+    }
+}

--- a/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
+++ b/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
@@ -24,12 +24,18 @@ namespace EasyRabbitFlow.Services
         /// <param name="message">The message to publish.</param>
         /// <param name="exchangeName">The name of the exchange to publish the message to.</param>
         /// <param name="routingKey">The routing key for the message.</param>
+        /// <param name="messageId">
+        /// Optional deterministic identifier for the message. Pass a key derived from your business data
+        /// (e.g. <c>OrderId + Operation</c>) when you need true publish-side idempotency — retries of the same logical
+        /// publish will then carry the same <c>MessageId</c> and consumers can deduplicate. When <c>null</c> (default),
+        /// a unique GUID is generated automatically.
+        /// </param>
         /// <param name="correlationId">An optional correlation identifier for tracing related messages.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="PublishResult"/> describing the outcome of the publish operation.</returns>
-        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string exchangeName, string routingKey, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string exchangeName, string routingKey, string? messageId = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
 
         /// <summary>
@@ -39,12 +45,18 @@ namespace EasyRabbitFlow.Services
         /// <typeparam name="TEvent">The type of the message to publish.</typeparam>
         /// <param name="message">The message to publish.</param>
         /// <param name="queueName">The name of the queue to publish the message to.</param>
+        /// <param name="messageId">
+        /// Optional deterministic identifier for the message. Pass a key derived from your business data
+        /// (e.g. <c>OrderId + Operation</c>) when you need true publish-side idempotency — retries of the same logical
+        /// publish will then carry the same <c>MessageId</c> and consumers can deduplicate. When <c>null</c> (default),
+        /// a unique GUID is generated automatically.
+        /// </param>
         /// <param name="correlationId">An optional correlation identifier for tracing related messages.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="PublishResult"/> describing the outcome of the publish operation.</returns>
-        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string queueName, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<PublishResult> PublishAsync<TEvent>(TEvent message, string queueName, string? messageId = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
         /// <summary>
         /// Asynchronously publishes a batch of messages to a RabbitMQ exchange.
@@ -60,12 +72,17 @@ namespace EasyRabbitFlow.Services
         /// <param name="exchangeName">The name of the exchange to publish messages to.</param>
         /// <param name="routingKey">The routing key for the messages.</param>
         /// <param name="channelMode">The channel mode for the batch operation. Defaults to <see cref="ChannelMode.Transactional"/>.</param>
+        /// <param name="messageIdSelector">
+        /// Optional selector that produces a deterministic <c>MessageId</c> per event (for true idempotency from business data).
+        /// When <c>null</c> (default), each message gets an auto-generated unique GUID. The selector must return a
+        /// non-empty string; an empty/null result causes the batch to fail (rolled back in <c>Transactional</c> mode).
+        /// </param>
         /// <param name="correlationId">An optional correlation identifier shared by all messages in the batch.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="BatchPublishResult"/> describing the outcome of the batch publish operation.</returns>
-        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, Func<TEvent, string>? messageIdSelector = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
 
         /// <summary>
         /// Asynchronously publishes a batch of messages to a RabbitMQ queue.
@@ -80,12 +97,17 @@ namespace EasyRabbitFlow.Services
         /// <param name="messages">The collection of messages to publish.</param>
         /// <param name="queueName">The name of the queue to publish messages to.</param>
         /// <param name="channelMode">The channel mode for the batch operation. Defaults to <see cref="ChannelMode.Transactional"/>.</param>
+        /// <param name="messageIdSelector">
+        /// Optional selector that produces a deterministic <c>MessageId</c> per event (for true idempotency from business data).
+        /// When <c>null</c> (default), each message gets an auto-generated unique GUID. The selector must return a
+        /// non-empty string; an empty/null result causes the batch to fail (rolled back in <c>Transactional</c> mode).
+        /// </param>
         /// <param name="correlationId">An optional correlation identifier shared by all messages in the batch.</param>
         /// <param name="publisherId">An optional identifier for the publisher connection.</param>
         /// <param name="jsonOptions">Optional JSON serializer options.</param>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A <see cref="BatchPublishResult"/> describing the outcome of the batch publish operation.</returns>
-        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
+        Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, Func<TEvent, string>? messageIdSelector = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonOptions = null, CancellationToken cancellationToken = default) where TEvent : class;
     }
 
     internal sealed class RabbitFlowPublisher : IRabbitFlowPublisher
@@ -111,27 +133,27 @@ namespace EasyRabbitFlow.Services
             this.publisherOptions = publisherOptions ?? new PublisherOptions();
         }
 
-        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string exchangeName, string routingKey = "", string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string exchangeName, string routingKey = "", string? messageId = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishMessageAsync(@event, exchangeName, routingKey, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
+            return await PublishMessageAsync(@event, exchangeName, routingKey, messageId, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
         }
 
-        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string queueName, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<PublishResult> PublishAsync<TEvent>(TEvent @event, string queueName, string? messageId = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishMessageAsync(@event, queueName, "", correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
+            return await PublishMessageAsync(@event, queueName, "", messageId, correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
         }
 
-        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string exchangeName, string routingKey, ChannelMode channelMode = ChannelMode.Transactional, Func<TEvent, string>? messageIdSelector = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishBatchInternalAsync(messages, exchangeName, routingKey, channelMode, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
+            return await PublishBatchInternalAsync(messages, exchangeName, routingKey, channelMode, messageIdSelector, correlationId, publisherId, jsonSerializerOptions, isQueue: false, cancellationToken);
         }
 
-        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<BatchPublishResult> PublishBatchAsync<TEvent>(IReadOnlyList<TEvent> messages, string queueName, ChannelMode channelMode = ChannelMode.Transactional, Func<TEvent, string>? messageIdSelector = null, string? correlationId = null, string publisherId = "", JsonSerializerOptions? jsonSerializerOptions = null, CancellationToken cancellationToken = default) where TEvent : class
         {
-            return await PublishBatchInternalAsync(messages, queueName, "", channelMode, correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
+            return await PublishBatchInternalAsync(messages, queueName, "", channelMode, messageIdSelector, correlationId, publisherId, jsonSerializerOptions, isQueue: true, cancellationToken);
         }
 
-        private async Task<PublishResult> PublishMessageAsync<TEvent>(TEvent @event, string destination, string routingKey, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
+        private async Task<PublishResult> PublishMessageAsync<TEvent>(TEvent @event, string destination, string routingKey, string? messageId, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
         {
             if (@event is null)
             {
@@ -140,7 +162,7 @@ namespace EasyRabbitFlow.Services
 
             publisherId ??= isQueue ? destination : string.Concat(destination, "_", routingKey);
 
-            string? messageId = publisherOptions.IdempotencyEnabled ? Guid.NewGuid().ToString("N") : null;
+            var resolvedMessageId = string.IsNullOrEmpty(messageId) ? Guid.NewGuid().ToString("N") : messageId!;
 
             var connection = await ResolveConnection(publisherId);
 
@@ -150,18 +172,18 @@ namespace EasyRabbitFlow.Services
 
             try
             {
-                await PublishToChannelAsync(channel, @event, destination, routingKey, serializerOptions, isQueue, messageId, correlationId, cancellationToken);
+                await PublishToChannelAsync(channel, @event, destination, routingKey, serializerOptions, isQueue, resolvedMessageId, correlationId, cancellationToken);
 
                 logger.LogDebug("[RABBIT-FLOW]: Message of type {MessageType} published to {Destination}. MessageId={MessageId}",
-                    typeof(TEvent).FullName, destination, messageId ?? "(none)");
+                    typeof(TEvent).FullName, destination, resolvedMessageId);
 
-                return PublishResult.Successful(destination, routingKey, messageId);
+                return PublishResult.Successful(destination, routingKey, resolvedMessageId);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "[RABBIT-FLOW]: Error publishing message to {Destination}", destination);
 
-                return PublishResult.Failed(destination, routingKey, messageId, ex);
+                return PublishResult.Failed(destination, routingKey, resolvedMessageId, ex);
             }
             finally
             {
@@ -172,7 +194,7 @@ namespace EasyRabbitFlow.Services
             }
         }
 
-        private async Task<BatchPublishResult> PublishBatchInternalAsync<TEvent>(IReadOnlyList<TEvent> messages, string destination, string routingKey, ChannelMode channelMode, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
+        private async Task<BatchPublishResult> PublishBatchInternalAsync<TEvent>(IReadOnlyList<TEvent> messages, string destination, string routingKey, ChannelMode channelMode, Func<TEvent, string>? messageIdSelector, string? correlationId, string publisherId, JsonSerializerOptions? jsonSerializerOptions, bool isQueue, CancellationToken cancellationToken = default) where TEvent : class
         {
             if (messages is null || messages.Count == 0)
             {
@@ -207,14 +229,24 @@ namespace EasyRabbitFlow.Services
                         throw new ArgumentNullException($"messages[{i}]", "Message at index " + i + " is null.");
                     }
 
-                    string? messageId = publisherOptions.IdempotencyEnabled ? Guid.NewGuid().ToString("N") : null;
+                    string messageId;
+                    if (messageIdSelector != null)
+                    {
+                        var selected = messageIdSelector(msg);
+                        if (string.IsNullOrEmpty(selected))
+                        {
+                            throw new ArgumentException($"messageIdSelector returned a null or empty MessageId for messages[{i}].", nameof(messageIdSelector));
+                        }
+                        messageId = selected;
+                    }
+                    else
+                    {
+                        messageId = Guid.NewGuid().ToString("N");
+                    }
 
                     await PublishToChannelAsync(channel, msg, destination, routingKey, serializerOptions, isQueue, messageId, correlationId, cancellationToken);
 
-                    if (messageId != null)
-                    {
-                        messageIds.Add(messageId);
-                    }
+                    messageIds.Add(messageId);
                 }
 
                 if (channelMode == ChannelMode.Transactional)

--- a/src/RabbitFlow/Settings/ConsumerSettings.cs
+++ b/src/RabbitFlow/Settings/ConsumerSettings.cs
@@ -156,5 +156,25 @@ namespace EasyRabbitFlow.Settings
 
             _services.AddSingleton(customDeasLetter);
         }
+
+        /// <summary>
+        /// Configures the dead-letter reprocessor for the consumer.
+        /// When enabled, a background service periodically drains the consumer's auto-generated dead-letter queue
+        /// and re-publishes messages to the main queue until <see cref="DeadLetterReprocessSettings{TConsumer}.MaxReprocessAttempts"/> is reached.
+        /// </summary>
+        /// <remarks>
+        /// Requires <see cref="AutoGenerate"/> to be <c>true</c>; otherwise the reprocessor is ignored.
+        /// When the reprocessor is active, <see cref="ExtendDeadletterMessage"/> is forced to <c>true</c> because the reprocessor
+        /// relies on the dead-letter envelope wrapping to track attempt counts and recover the original payload.
+        /// </remarks>
+        /// <param name="settings">An action to configure the reprocessor settings.</param>
+        public void ConfigureDeadLetterReprocess(Action<DeadLetterReprocessSettings<TConsumer>> settings)
+        {
+            var reprocessSettings = new DeadLetterReprocessSettings<TConsumer>();
+
+            settings.Invoke(reprocessSettings);
+
+            _services.AddSingleton(reprocessSettings);
+        }
     }
 }

--- a/src/RabbitFlow/Settings/DeadLetterEnvelope.cs
+++ b/src/RabbitFlow/Settings/DeadLetterEnvelope.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EasyRabbitFlow.Settings
+{
+    /// <summary>
+    /// Wrapper written to a dead-letter queue when <see cref="ConsumerSettings{TConsumer}.ExtendDeadletterMessage"/> is enabled.
+    /// Carries the original message payload together with failure metadata.
+    /// </summary>
+    public sealed class DeadLetterEnvelope
+    {
+        /// <summary>UTC timestamp at which the failure was recorded.</summary>
+        [JsonPropertyName("dateUtc")]
+        public DateTime DateUtc { get; set; }
+
+        /// <summary>The CLR type name of the original event.</summary>
+        [JsonPropertyName("messageType")]
+        public string? MessageType { get; set; }
+
+        /// <summary>
+        /// The <c>MessageId</c> of the original message, captured from <c>BasicProperties</c> when the failure was recorded.
+        /// Preserved so the reprocessor can restore it when re-publishing to the main queue.
+        /// </summary>
+        [JsonPropertyName("messageId")]
+        public string? MessageId { get; set; }
+
+        /// <summary>
+        /// The <c>CorrelationId</c> of the original message, captured from <c>BasicProperties</c> when the failure was recorded.
+        /// Preserved so the reprocessor can restore it when re-publishing to the main queue.
+        /// </summary>
+        [JsonPropertyName("correlationId")]
+        public string? CorrelationId { get; set; }
+
+        /// <summary>
+        /// The original message payload, stored as a raw JSON element so it can be re-published byte-equivalently
+        /// regardless of whether the payload is an object, array, string, number, boolean or null.
+        /// </summary>
+        [JsonPropertyName("messageData")]
+        public JsonElement? MessageData { get; set; }
+
+        /// <summary>The CLR type name of the exception that caused the failure.</summary>
+        [JsonPropertyName("exceptionType")]
+        public string? ExceptionType { get; set; }
+
+        /// <summary>The exception message.</summary>
+        [JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+
+        /// <summary>The exception stack trace.</summary>
+        [JsonPropertyName("stackTrace")]
+        public string? StackTrace { get; set; }
+
+        /// <summary>The exception <c>Source</c> property.</summary>
+        [JsonPropertyName("source")]
+        public string? Source { get; set; }
+
+        /// <summary>Inner exception chain captured at the time of failure.</summary>
+        [JsonPropertyName("innerExceptions")]
+        public List<DeadLetterInnerException> InnerExceptions { get; set; } = new List<DeadLetterInnerException>();
+
+        /// <summary>
+        /// Number of times this message has been re-queued from the dead-letter queue back to the main queue
+        /// by the dead-letter reprocessor. <c>0</c> means the message has not been reprocessed yet.
+        /// </summary>
+        [JsonPropertyName("reprocessAttempts")]
+        public int ReprocessAttempts { get; set; }
+    }
+
+    /// <summary>
+    /// Inner exception entry inside a <see cref="DeadLetterEnvelope"/>.
+    /// </summary>
+    public sealed class DeadLetterInnerException
+    {
+        /// <summary>The CLR type name of the inner exception.</summary>
+        [JsonPropertyName("exceptionType")]
+        public string? ExceptionType { get; set; }
+
+        /// <summary>The inner exception message.</summary>
+        [JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+
+        /// <summary>The inner exception stack trace.</summary>
+        [JsonPropertyName("stackTrace")]
+        public string? StackTrace { get; set; }
+
+        /// <summary>The inner exception <c>Source</c> property.</summary>
+        [JsonPropertyName("source")]
+        public string? Source { get; set; }
+    }
+}

--- a/src/RabbitFlow/Settings/DeadLetterReprocessSettings.cs
+++ b/src/RabbitFlow/Settings/DeadLetterReprocessSettings.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace EasyRabbitFlow.Settings
+{
+    /// <summary>
+    /// Configuration for the dead-letter reprocessor associated with a consumer.
+    /// When enabled, a background service periodically drains the consumer's auto-generated dead-letter queue
+    /// and re-publishes messages to the main queue until <see cref="MaxReprocessAttempts"/> is reached.
+    /// </summary>
+    /// <remarks>
+    /// Requires <see cref="ConsumerSettings{TConsumer}.AutoGenerate"/> to be <c>true</c>; otherwise the reprocessor is ignored.
+    /// When the reprocessor is active, <see cref="ConsumerSettings{TConsumer}.ExtendDeadletterMessage"/> is forced to <c>true</c>
+    /// because the reprocessor relies on the <see cref="DeadLetterEnvelope"/> wrapping to track attempt counts and recover the original payload.
+    /// </remarks>
+    /// <typeparam name="TConsumer">The consumer this configuration applies to.</typeparam>
+    public class DeadLetterReprocessSettings<TConsumer> where TConsumer : class
+    {
+        /// <summary>
+        /// Whether the reprocessor is enabled for this consumer. Default is <c>true</c>;
+        /// the configuration only takes effect once <c>ConfigureDeadLetterReprocess</c> is called.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Maximum number of times a single message will be moved from the dead-letter queue back to the main queue.
+        /// When this count is reached, the message stays in the dead-letter queue with the final attempt count recorded
+        /// in its envelope so it can be inspected from a RabbitMQ client. Default is <c>3</c>.
+        /// </summary>
+        public int MaxReprocessAttempts
+        {
+            get => _maxReprocessAttempts;
+            set => _maxReprocessAttempts = value < 1
+                ? throw new ArgumentOutOfRangeException(nameof(MaxReprocessAttempts), "MaxReprocessAttempts must be greater than 0.")
+                : value;
+        }
+
+        private int _maxReprocessAttempts = 3;
+
+        /// <summary>
+        /// Interval between reprocessor runs. The reprocessor is intended for slow, recovery-oriented retry of messages
+        /// whose underlying failure takes a while to resolve — use the in-handler <c>RetryPolicy</c> for short retry windows.
+        /// Default is 3 hours. <b>Minimum allowed is 10 minutes</b> and this floor cannot be lowered.
+        /// </summary>
+        public TimeSpan Interval
+        {
+            get => _interval;
+            set => _interval = value < MinimumInterval
+                ? throw new ArgumentOutOfRangeException(nameof(Interval), $"Interval must be at least {MinimumInterval.TotalMinutes} minute(s). Use the in-handler RetryPolicy for tighter retry cadences.")
+                : value;
+        }
+
+        private TimeSpan _interval = TimeSpan.FromHours(3);
+
+        /// <summary>
+        /// Hard lower bound for <see cref="Interval"/>. Exposed as <c>readonly</c> so it cannot be lowered at runtime.
+        /// </summary>
+        public static readonly TimeSpan MinimumInterval = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// Hard upper bound on the number of messages drained from the dead-letter queue in a single cycle.
+        /// By default the cycle drains the whole queue snapshot taken at the start of the run; lower this value
+        /// only if you need an explicit safety ceiling.
+        /// </summary>
+        /// <remarks>
+        /// The cycle always takes a snapshot of the DLQ length at the start and never reprocesses messages it has
+        /// just re-published within the same cycle, so this property is purely an additional safety cap — not
+        /// required for correctness. Default is <see cref="int.MaxValue"/>.
+        /// </remarks>
+        public int MaxMessagesPerCycle
+        {
+            get => _maxMessagesPerCycle;
+            set => _maxMessagesPerCycle = value < 1
+                ? throw new ArgumentOutOfRangeException(nameof(MaxMessagesPerCycle), "MaxMessagesPerCycle must be greater than 0.")
+                : value;
+        }
+
+        private int _maxMessagesPerCycle = int.MaxValue;
+    }
+}

--- a/src/RabbitFlow/Settings/PublishResult.cs
+++ b/src/RabbitFlow/Settings/PublishResult.cs
@@ -15,11 +15,11 @@ namespace EasyRabbitFlow.Settings
         public bool Success { get; }
 
         /// <summary>
-        /// Gets the unique identifier assigned to the published message.
-        /// When <see cref="PublisherOptions.IdempotencyEnabled"/> is <c>true</c>, this value is automatically generated
-        /// and can be used for deduplication on the consumer side.
+        /// Gets the identifier assigned to the published message. Always populated:
+        /// either the value supplied by the caller via the <c>messageId</c> parameter (deterministic key for idempotency),
+        /// or a unique GUID generated automatically when no value is supplied.
         /// </summary>
-        public string? MessageId { get; }
+        public string MessageId { get; }
 
         /// <summary>
         /// Gets the destination exchange or queue name used for the publish operation.
@@ -43,7 +43,7 @@ namespace EasyRabbitFlow.Settings
         /// </summary>
         public Exception? Error { get; }
 
-        private PublishResult(bool success, string destination, string routingKey, string? messageId, Exception? error)
+        private PublishResult(bool success, string destination, string routingKey, string messageId, Exception? error)
         {
             Success = success;
             Destination = destination;
@@ -53,10 +53,10 @@ namespace EasyRabbitFlow.Settings
             Error = error;
         }
 
-        internal static PublishResult Successful(string destination, string routingKey, string? messageId)
+        internal static PublishResult Successful(string destination, string routingKey, string messageId)
             => new PublishResult(true, destination, routingKey, messageId, null);
 
-        internal static PublishResult Failed(string destination, string routingKey, string? messageId, Exception error)
+        internal static PublishResult Failed(string destination, string routingKey, string messageId, Exception error)
             => new PublishResult(false, destination, routingKey, messageId, error);
     }
 
@@ -89,8 +89,9 @@ namespace EasyRabbitFlow.Settings
         public int MessageCount { get; }
 
         /// <summary>
-        /// Gets the list of message identifiers assigned to each message in the batch.
-        /// Only populated when <see cref="PublisherOptions.IdempotencyEnabled"/> is <c>true</c>.
+        /// Gets the identifiers assigned to each message in the batch, in the same order as the input list.
+        /// Always populated with one entry per published message — either the value produced by the
+        /// <c>messageIdSelector</c> argument or a unique GUID generated automatically when no selector is supplied.
         /// </summary>
         public IReadOnlyList<string> MessageIds { get; }
 

--- a/src/RabbitFlow/Settings/PublisherOptions.cs
+++ b/src/RabbitFlow/Settings/PublisherOptions.cs
@@ -13,18 +13,7 @@
         /// If set to <c>false</c>, the connection remains open for reuse, which can improve performance in high-throughput scenarios.
         /// Default value is false.
         /// </summary>
-
         public bool DisposePublisherConnection { get; set; } = false;
-
-
-        /// <summary>
-        /// Gets or sets a value indicating whether idempotency support is enabled for published messages.
-        /// When <c>true</c>, the publisher automatically assigns a unique <c>MessageId</c> to each message
-        /// via <see cref="RabbitMQ.Client.IBasicProperties.MessageId"/>. Consumers can use this value 
-        /// for deduplication. The generated <c>MessageId</c> is also available in <see cref="PublishResult.MessageId"/>.
-        /// Default value is <c>false</c>.
-        /// </summary>
-        public bool IdempotencyEnabled { get; set; } = false;
     }
 
     /// <summary>

--- a/src/RabbitFlow/Settings/RabbitFlowHeaders.cs
+++ b/src/RabbitFlow/Settings/RabbitFlowHeaders.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace EasyRabbitFlow.Settings
+{
+    /// <summary>
+    /// Internal AMQP header names and helpers used by EasyRabbitFlow.
+    /// </summary>
+    internal static class RabbitFlowHeaders
+    {
+        /// <summary>
+        /// Header carrying the current reprocess-attempt counter as a message travels from the
+        /// dead-letter queue back to the main queue and (if it fails again) into the dead-letter envelope.
+        /// </summary>
+        public const string ReprocessAttempts = "x-reprocess-attempts";
+
+        /// <summary>
+        /// Reads the <see cref="ReprocessAttempts"/> AMQP header in a defensive way (RabbitMQ.Client
+        /// may surface header values as <c>int</c>, <c>long</c>, <c>byte[]</c>, <c>string</c>, etc.).
+        /// Returns <c>0</c> when the header is missing or unparseable.
+        /// </summary>
+        public static int ReadReprocessAttempts(IDictionary<string, object?>? headers)
+        {
+            if (headers == null) 
+                return 0;
+
+            if (!headers.TryGetValue(ReprocessAttempts, out var raw) || raw == null) 
+                return 0;
+
+            return raw switch
+            {
+                int i => i,
+                long l => (int)l,
+                short s => s,
+                byte b => b,
+                byte[] bytes => int.TryParse(Encoding.UTF8.GetString(bytes), out var parsedBytes) ? parsedBytes : 0,
+                string str => int.TryParse(str, out var parsedStr) ? parsedStr : 0,
+                _ => 0,
+            };
+        }
+    }
+}

--- a/src/RabbitFlow/Settings/RabbitFlowMessageContext.cs
+++ b/src/RabbitFlow/Settings/RabbitFlowMessageContext.cs
@@ -15,7 +15,8 @@ namespace EasyRabbitFlow.Settings
             string? routingKey,
             IDictionary<string, object?>? headers,
             ulong deliveryTag,
-            bool redelivered)
+            bool redelivered,
+            int reprocessAttempts)
         {
             MessageId = messageId;
             CorrelationId = correlationId;
@@ -24,13 +25,14 @@ namespace EasyRabbitFlow.Settings
             Headers = headers;
             DeliveryTag = deliveryTag;
             Redelivered = redelivered;
+            ReprocessAttempts = reprocessAttempts;
         }
 
         /// <summary>
-        /// Gets the <c>MessageId</c> from <c>BasicProperties</c>.
-        /// When the publisher has <see cref="PublisherOptions.IdempotencyEnabled"/> set to <c>true</c>,
-        /// this contains the unique identifier assigned to the message for deduplication.
-        /// <c>null</c> when the publisher did not set a <c>MessageId</c>.
+        /// Gets the <c>MessageId</c> from <c>BasicProperties</c>. Always populated when the message was published
+        /// via <see cref="Services.IRabbitFlowPublisher"/> (either the deterministic key supplied by the caller
+        /// or an auto-generated GUID). May be <c>null</c> only if the message originated from a third-party publisher
+        /// that did not set <c>BasicProperties.MessageId</c>.
         /// </summary>
         public string? MessageId { get; }
 
@@ -66,5 +68,12 @@ namespace EasyRabbitFlow.Settings
         /// Gets a value indicating whether this message was redelivered by the broker.
         /// </summary>
         public bool Redelivered { get; }
+
+        /// <summary>
+        /// Number of times this message has been re-enqueued from the dead-letter queue back to the main queue
+        /// by the dead-letter reprocessor. <c>0</c> for messages that have not been reprocessed.
+        /// Sourced from the <c>x-reprocess-attempts</c> AMQP header.
+        /// </summary>
+        public int ReprocessAttempts { get; }
     }
 }


### PR DESCRIPTION
Introduces a new dead-letter reprocessor that periodically drains the auto-generated DLQ of every configured consumer and re-enqueues messages to the main queue until a maximum attempt count is reached.

Reprocessor highlights:
- ConfigureDeadLetterReprocess(...) on ConsumerSettings, following the same pattern as ConfigureRetryPolicy / ConfigureAutoGenerate.
- DeadLetterReprocessorHostedService registered by UseRabbitFlowConsumers, which spawns one worker per consumer with the feature enabled.
- Only transient failures (OperationCanceledException, TaskCanceledException, RabbitFlowTransientException) are reprocessed; permanent failures stay in the DLQ for inspection.
- Attempt count survives the DLQ -> main -> DLQ cycle via the x-reprocess-attempts AMQP header and is exposed to consumers as RabbitFlowMessageContext.ReprocessAttempts.
- Interval has a 10-minute floor; MaxMessagesPerCycle defaults to draining the DLQ snapshot in full and acts as an optional safety cap.
- Requires AutoGenerate=true and forces ExtendDeadletterMessage=true.

Idempotency rework (breaking):
- PublisherOptions.IdempotencyEnabled removed. Every published message always carries a MessageId.
- PublishAsync gains an optional messageId parameter and PublishBatchAsync gains a Func<TEvent, string>? messageIdSelector parameter so callers can supply a deterministic key derived from business data for true idempotency.
- PublishResult.MessageId is now non-nullable; BatchPublishResult.MessageIds always contains one entry per published message.

Other changes:
- DeadLetterEnvelope (public) replaces the anonymous extended dead-letter payload, with JsonElement MessageData to preserve any payload type byte-equivalently and new MessageId / CorrelationId / ReprocessAttempts fields. Backward-compatible JSON keys preserved.
- RabbitFlowHeaders.ReadReprocessAttempts shared between the modern and obsolete consumer paths.
- README rewritten with a v6 breaking-changes block, dead-letter reprocessor section, and an idempotency section explaining the difference between auto-GUID tracking and caller-supplied keys.
- CI workflow: push-only trigger and single .NET 8.x SDK install (tests target net8.0 only).

Version bumped to 6.0.0.