### PR TITLE
feat: add DLQ envelope unwrap and reserved-name validation (v6.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ public Task HandleAsync(MyEvent message, RabbitFlowMessageContext context, Cance
 - [Consumers](#consumers)
   - [Implementing a Consumer](#implementing-a-consumer)
   - [Registering Consumers](#registering-consumers)
+  - [Reserved Name Substrings](#reserved-name-substrings)
   - [Auto-Generate Topology](#auto-generate-topology)
   - [Retry Policies](#retry-policies)
   - [Consumer Timeout](#consumer-timeout)
   - [Custom Dead-Letter Queues](#custom-dead-letter-queues)
   - [Dead-Letter Reprocessor](#dead-letter-reprocessor)
+  - [Manual DLQ Replay Safety Net](#manual-dlq-replay-safety-net)
 - [Publishing Messages](#publishing-messages)
   - [Single Message](#single-message)
   - [Batch Publishing](#batch-publishing)
@@ -380,7 +382,7 @@ cfg.ConfigureJsonSerializerOptions(json =>
 });
 ```
 
-If not configured, the default `JsonSerializerOptions` are used.
+If not configured, EasyRabbitFlow falls back to `JsonSerializerOptions.Web` — i.e. camelCase property naming with case-insensitive deserialization, the same defaults ASP.NET Core uses for JSON. Override via `ConfigureJsonSerializerOptions` if you need a different policy.
 
 ### Publisher Options
 
@@ -460,6 +462,57 @@ cfg.AddConsumer<EmailConsumer>("email-queue", c =>
 | `AutoAckOnError` | bool | `false` | Auto-acknowledge on error (message lost) |
 | `AutoGenerate` | bool | `false` | Auto-create queue/exchange/DLQ |
 | `ExtendDeadletterMessage` | bool | `true` | Enrich dead-letter messages with error details |
+| `UnwrapDeadLetterEnvelopes` | bool | `false` | Defensive safety net: detect a `DeadLetterEnvelope` arriving on the main queue (e.g. from a manual DLQ replay) and process the inner payload. See [Manual DLQ Replay Safety Net](#manual-dlq-replay-safety-net). |
+| `DisableNameValidation` | bool | `false` | Skip validation of reserved substrings (`deadletter`, `-exchange`, `-routing-key`) against the queue name and any auto-generate names. See [Reserved Name Substrings](#reserved-name-substrings). Only honored when `AutoGenerate = false`. |
+
+### Reserved Name Substrings
+
+When `AutoGenerate = true`, EasyRabbitFlow derives the dead-letter topology by appending fixed substrings to the user-supplied queue name:
+
+```text
+{queueName}-deadletter
+{queueName}-deadletter-exchange
+{queueName}-deadletter-routing-key
+```
+
+To prevent collisions and ambiguous topology, `AddConsumer<T>` validates the supplied `queueName` (and any `ExchangeName` / `RoutingKey` configured via `ConfigureAutoGenerate`) against three reserved substrings — case-insensitive:
+
+- `deadletter`
+- `-exchange`
+- `-routing-key`
+
+If any name contains one of these, registration throws `RabbitFlowException`:
+
+```csharp
+// Throws — "orders-deadletter" collides with the auto-generated DLQ name.
+cfg.AddConsumer<OrderConsumer>("orders-deadletter", c => { /* ... */ });
+```
+
+```csharp
+// Throws — auto-generate exchange/routing-key names follow the same rule.
+cfg.AddConsumer<OrderConsumer>("orders", c =>
+{
+    c.AutoGenerate = true;
+    c.ConfigureAutoGenerate(ag =>
+    {
+        ag.ExchangeName = "orders-exchange"; // throws
+    });
+});
+```
+
+**Opting out (`DisableNameValidation`)**
+
+If you fully own the broker topology — i.e. `AutoGenerate = false` and the framework never derives any dependent names — you can bypass the validation:
+
+```csharp
+cfg.AddConsumer<OrderConsumer>("orders-deadletter-archive", c =>
+{
+    c.AutoGenerate = false;          // required
+    c.DisableNameValidation = true;  // explicitly accept the reserved substring
+});
+```
+
+`DisableNameValidation` is **silently ignored** when `AutoGenerate = true`, because the framework still needs to append the reserved suffixes to derive the DLQ topology and a collision would produce ambiguous queue/exchange names.
 
 ### Auto-Generate Topology
 
@@ -688,6 +741,40 @@ If a message exhausts its reprocess budget, the reprocessor re-publishes it back
 - Operates only on the auto-generated dead-letter queue (`{queue}-deadletter`). Messages routed via `ConfigureCustomDeadletter` are not processed.
 - **Only transient failures are reprocessed.** A message is eligible only if its `exceptionType` in the envelope is `OperationCanceledException`, `TaskCanceledException`, or `RabbitFlowTransientException` — the same set the in-handler `RetryPolicy` retries. Permanent failures (validation, deserialization, business-rule violations) stay in the DLQ untouched so they remain visible for inspection.
 - Counter persistence: the reprocessor sets the AMQP header `x-reprocess-attempts` on every message it re-publishes. The consumer reads this header on receipt and seeds the new envelope with that count if processing fails again, so the counter survives the full cycle DLQ → main → DLQ.
+
+### Manual DLQ Replay Safety Net
+
+The recommended way to retry dead-lettered messages is the [Dead-Letter Reprocessor](#dead-letter-reprocessor) — it preserves the original payload and the `reprocessAttempts` counter for you. But operators occasionally replay a message manually (Shovel plugin, management UI, ad-hoc script) by copying it from the DLQ back to the main queue. When that happens, the message body is no longer the original event — it is a `DeadLetterEnvelope` JSON, which deserializes into a default-shaped `TEvent` and silently corrupts the consumer's view of the world.
+
+`UnwrapDeadLetterEnvelopes` is an opt-in defense for that scenario:
+
+```csharp
+cfg.AddConsumer<OrderConsumer>("orders-queue", c =>
+{
+    c.AutoGenerate = true;
+    c.ExtendDeadletterMessage = true;
+    c.UnwrapDeadLetterEnvelopes = true;  // safety net for manual replays
+});
+```
+
+**How it works**
+
+For every inbound message, the consumer runs a cheap byte-level fingerprint scan looking for the two most distinctive envelope keys (`"messageData"` and `"exceptionType"`). Only when the fingerprint matches does it parse the body as `DeadLetterEnvelope`, extract the inner `MessageData`, and use it as the actual payload. If the envelope carried a `MessageId` or `CorrelationId`, those are also surfaced via `RabbitFlowMessageContext` when AMQP didn't already provide them.
+
+A warning is logged whenever an unwrap fires, so you can spot manual replays in the logs:
+
+```text
+[RABBIT-FLOW]: Detected manually replayed DeadLetterEnvelope on queue orders-queue for OrderConsumer;
+unwrapped inner payload. Prefer the DeadLetterReprocessor for replays.
+```
+
+**No double-wrapping on re-failure**
+
+If the unwrapped message fails again with `ExtendDeadletterMessage = true`, the new DLQ entry wraps the **original payload**, not the inbound envelope — the dead-letter queue stays at depth 1 instead of accumulating nested envelopes across replays.
+
+**Default is `false`**
+
+The fingerprint check is fast, but it still runs on every message. Leave the flag off unless you actually need the safety net — i.e. unless your operations team manually replays messages from the DLQ. Production deployments that rely exclusively on the reprocessor never need to enable it.
 
 ---
 

--- a/sample/RabbitFlowSample/Program.cs
+++ b/sample/RabbitFlowSample/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddRabbitFlow(settings =>
 
         consumerSettings.ExtendDeadletterMessage = true;
 
+        consumerSettings.UnwrapDeadLetterEnvelopes = true;
     });
 
     settings.AddConsumer<WhatsAppConsumer>(queueName: "whatsapp-queue", consumerSettings =>

--- a/src/RabbitFlow/EasyRabbitFlow.csproj
+++ b/src/RabbitFlow/EasyRabbitFlow.csproj
@@ -6,7 +6,7 @@
 		<Title>EasyRabbitFlow</Title>
 		<Authors>Juan Carlos Torres Cuervo</Authors>
 		<Description>EasyRabbitFlow: high-performance RabbitMQ client for .NET. Fluent configuration, optional topology (queue/exchange/dead-letter) generation, reflection-free consumers, configurable retry (exponential/backoff), custom dead-letter routing, temporary batch processing, queue state helpers. Targets .NET Standard 2.1.</Description>
-		<Version>6.0.1</Version>
+		<Version>6.0.2</Version>
 		<PackageTags>rabbitmq;dotnet;messaging;queue;consumer;publisher;retry;deadletter;backoff;temporary;batch</PackageTags>
 		<PackageProjectUrl>https://github.com/devjuanca/EasyRabbitFlow</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/devjuanca/EasyRabbitFlow</RepositoryUrl>

--- a/src/RabbitFlow/Services/ConsumerHostedService.cs
+++ b/src/RabbitFlow/Services/ConsumerHostedService.cs
@@ -42,10 +42,7 @@ namespace EasyRabbitFlow.Services
 
             var connectionFactory = _root.GetRequiredService<ConnectionFactory>();
 
-            var serializerOptions = _root.GetKeyedService<JsonSerializerOptions>("RabbitFlowJsonSerializer") ?? new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
+            var serializerOptions = _root.GetKeyedService<JsonSerializerOptions>("RabbitFlowJsonSerializer") ?? JsonSerializerOptions.Web;
 
             foreach (var marker in markers)
             {
@@ -87,7 +84,6 @@ namespace EasyRabbitFlow.Services
         private readonly ConnectionFactory _connectionFactory;
         private readonly JsonSerializerOptions _serializerOptions;
         private readonly IConsumerSettingsMarker _marker;
-
         private readonly ConsumerSettingsFactory _markerFactory;
         private readonly Type _consumerType;
         private readonly Type _eventType;
@@ -98,18 +94,16 @@ namespace EasyRabbitFlow.Services
         private readonly bool _autoGenerate;
         private readonly bool _extendDeadLetter;
         private readonly bool _autoAckOnError;
-
+        private readonly bool _unwrapEnvelopes;
         private readonly int _rpMax;
         private readonly int _totalAttempts;
         private readonly int _rpInterval;
         private readonly bool _rpExp;
         private readonly int _rpFactor;
         private readonly int _rpMaxDelay;
-
         private readonly object? _customDeadLetterObj;
         private readonly object? _autoGenObj;
         private readonly long _serverConsumerTimeoutMs;
-
         private readonly SemaphoreSlim _channelGate = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _recoveryGate = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _prefetchSemaphore;
@@ -136,14 +130,24 @@ namespace EasyRabbitFlow.Services
             var settings = marker.SettingsInstance;
 
             _markerFactory = marker.Factory;
+            
             _consumerType = marker.ConsumerType;
+            
             _eventType = marker.EventType;
+            
             _queueName = settings.QueueName;
+            
             _consumerId = settings.ConsumerId ?? settings.QueueName;
+            
             _timeout = settings.Timeout;
+            
             _prefetch = settings.PrefetchCount;
+            
             _autoGenerate = settings.AutoGenerate;
+
             _autoAckOnError = settings.AutoAckOnError;
+
+            _unwrapEnvelopes = settings.UnwrapDeadLetterEnvelopes;
 
             var reprocessObj = root.GetService(typeof(DeadLetterReprocessSettings<>).MakeGenericType(_consumerType));
 
@@ -170,11 +174,20 @@ namespace EasyRabbitFlow.Services
             var rpType = retryPolicyObj.GetType();
 
             _rpMax = (int)rpType.GetProperty(nameof(RetryPolicy<object>.MaxRetryCount))!.GetValue(retryPolicyObj)!;
-            if (_rpMax < 0) _rpMax = 0;
+
+            if (_rpMax < 0)
+            {
+                _rpMax = 0;
+            }
+
             _totalAttempts = _rpMax + 1;
+            
             _rpInterval = (int)rpType.GetProperty(nameof(RetryPolicy<object>.RetryInterval))!.GetValue(retryPolicyObj)!;
+            
             _rpExp = (bool)rpType.GetProperty(nameof(RetryPolicy<object>.ExponentialBackoff))!.GetValue(retryPolicyObj)!;
+            
             _rpFactor = (int)rpType.GetProperty(nameof(RetryPolicy<object>.ExponentialBackoffFactor))!.GetValue(retryPolicyObj)!;
+            
             _rpMaxDelay = (int)rpType.GetProperty(nameof(RetryPolicy<object>.MaxRetryDelay))!.GetValue(retryPolicyObj)!;
 
             _customDeadLetterObj = root.GetService(typeof(CustomDeadLetterSettings<>).MakeGenericType(_consumerType));
@@ -197,9 +210,13 @@ namespace EasyRabbitFlow.Services
                     try
                     {
                         var computed = checked((long)(_rpInterval * Math.Pow(_rpFactor, attemptIndex - 1)));
+                        
                         d = Math.Min(computed, _rpMaxDelay);
                     }
-                    catch { d = _rpMaxDelay; }
+                    catch 
+                    { 
+                        d = _rpMaxDelay; 
+                    }
                 }
 
                 sumRetryDelaysMs += d;
@@ -215,6 +232,7 @@ namespace EasyRabbitFlow.Services
             _lifetimeCt = cancellationToken;
 
             await EnsureConnectionAsync(cancellationToken);
+
             await EnsureChannelAsync(cancellationToken);
         }
 
@@ -223,6 +241,7 @@ namespace EasyRabbitFlow.Services
             _stopping = true;
 
             await _recoveryGate.WaitAsync();
+            
             try
             {
                 DisposeChannel();
@@ -250,8 +269,11 @@ namespace EasyRabbitFlow.Services
             _connection = await _connectionFactory.CreateConnectionAsync($"consumer_{_consumerId}", ct);
 
             _connection.ConnectionShutdownAsync += OnConnectionShutdownAsync;
+            
             _connection.CallbackExceptionAsync += OnConnectionCallbackExceptionAsync;
+            
             _connection.RecoverySucceededAsync += OnRecoverySucceededAsync;
+            
             _connection.ConnectionRecoveryErrorAsync += OnConnectionRecoveryErrorAsync;
         }
 
@@ -267,6 +289,7 @@ namespace EasyRabbitFlow.Services
             _channel = await _connection!.CreateChannelAsync(cancellationToken: ct);
 
             _channel.CallbackExceptionAsync += OnChannelCallbackExceptionAsync;
+            
             _channel.ChannelShutdownAsync += OnChannelShutdownAsync;
 
             await _channel.BasicQosAsync(0, _prefetch, false, ct);
@@ -323,15 +346,21 @@ namespace EasyRabbitFlow.Services
             if (generateDeadletter)
             {
                 _deadLetterQueueName = $"{_queueName}-deadletter";
+                
                 var deadLetterExchange = $"{_queueName}-deadletter-exchange";
+                
                 var deadLetterRoutingKey = $"{_queueName}-deadletter-routing-key";
 
                 await channel.QueueDeclareAsync(_deadLetterQueueName, durableQueue, false, autoDeleteQueue, null, cancellationToken: ct);
+                
                 await channel.ExchangeDeclareAsync(deadLetterExchange, "direct", durableExchange, cancellationToken: ct);
+                
                 await channel.QueueBindAsync(_deadLetterQueueName, deadLetterExchange, deadLetterRoutingKey);
 
                 args ??= new Dictionary<string, object?>();
+                
                 args["x-dead-letter-exchange"] = deadLetterExchange;
+                
                 args["x-dead-letter-routing-key"] = deadLetterRoutingKey;
             }
 
@@ -347,6 +376,7 @@ namespace EasyRabbitFlow.Services
             if (generateExchange)
             {
                 await channel.ExchangeDeclareAsync(exchangeName, exchangeType, durableExchange);
+                
                 await channel.QueueBindAsync(_queueName, exchangeName, routingKey);
             }
         }
@@ -354,6 +384,7 @@ namespace EasyRabbitFlow.Services
         private async Task ProcessMessageAsync(BasicDeliverEventArgs args)
         {
             var channel = _channel;
+            
             var rootCt = _lifetimeCt;
 
             try
@@ -366,10 +397,28 @@ namespace EasyRabbitFlow.Services
                 var body = args.Body.ToArray();
 
                 var reprocessAttempts = RabbitFlowHeaders.ReadReprocessAttempts(args.BasicProperties?.Headers);
+                
                 var msgId = args.BasicProperties?.MessageId;
+
                 var corrId = args.BasicProperties?.CorrelationId;
 
+                if (_unwrapEnvelopes
+                    && LooksLikeDeadLetterEnvelope(body)
+                    && TryUnwrapDeadLetterEnvelope(body, out var unwrappedBody, out var inboundEnvelope))
+                {
+                    body = unwrappedBody;
+
+                    msgId ??= inboundEnvelope!.MessageId;
+
+                    corrId ??= inboundEnvelope!.CorrelationId;
+
+                    _logger.LogWarning(
+                        "[RABBIT-FLOW]: Detected manually replayed DeadLetterEnvelope on queue {Queue} for {Consumer}; unwrapped inner payload. Prefer the DeadLetterReprocessor for replays.",
+                        _queueName, _consumerType.Name);
+                }
+
                 object? evt;
+
                 try
                 {
                     evt = _markerFactory.Deserialize(body, _serializerOptions) ?? throw new Exception("Deserialization returned null");
@@ -381,12 +430,15 @@ namespace EasyRabbitFlow.Services
                 }
 
                 int remainingAttempts = _totalAttempts;
+
                 Exception? lastException = null;
 
                 while (remainingAttempts > 0 && !rootCt.IsCancellationRequested)
                 {
                     using var attemptCts = new CancellationTokenSource(_timeout);
+                    
                     using var linked = CancellationTokenSource.CreateLinkedTokenSource(attemptCts.Token, rootCt);
+                    
                     var attemptCt = linked.Token;
 
                     using var scope = _root.CreateScope();
@@ -499,11 +551,16 @@ namespace EasyRabbitFlow.Services
         private async Task HandleErrorAsync(IChannel channel, ulong deliveryTag, object? evt, byte[]? body, int reprocessAttempts, string? messageId, string? correlationId, Exception exception, CancellationToken ct)
         {
             await _channelGate.WaitAsync(ct).ConfigureAwait(false);
+
             try
             {
                 if (_autoAckOnError)
                 {
-                    try { await channel.BasicAckAsync(deliveryTag, false, ct); } catch { }
+                    try 
+                    { 
+                        await channel.BasicAckAsync(deliveryTag, false, ct); 
+                    } 
+                    catch { }
                     return;
                 }
 
@@ -524,12 +581,15 @@ namespace EasyRabbitFlow.Services
                     };
 
                     const int MaxDepth = 10;
+                    
                     var temp = exception;
+                    
                     var depth = 0;
 
                     while (temp?.InnerException != null && depth < MaxDepth)
                     {
                         temp = temp.InnerException;
+
                         if (temp != null)
                         {
                             envelope.InnerExceptions.Add(new DeadLetterInnerException
@@ -546,14 +606,20 @@ namespace EasyRabbitFlow.Services
                     try
                     {
                         var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, _serializerOptions));
+                        
                         await channel.BasicPublishAsync(exchange: "", routingKey: _deadLetterQueueName, body: bytes, cancellationToken: ct);
+                        
                         await channel.BasicAckAsync(deliveryTag, false, ct);
                     }
                     catch { }
                 }
                 else
                 {
-                    try { await channel.BasicNackAsync(deliveryTag, false, false, ct); } catch { }
+                    try 
+                    { 
+                        await channel.BasicNackAsync(deliveryTag, false, false, ct);
+
+                    } catch { }
                 }
             }
             finally { _channelGate.Release(); }
@@ -562,6 +628,7 @@ namespace EasyRabbitFlow.Services
         private Task OnChannelCallbackExceptionAsync(object sender, CallbackExceptionEventArgs args)
         {
             _logger.LogWarning(args.Exception, "[RABBIT-FLOW]: Channel callback exception for {Consumer}.", _consumerType.Name);
+
             return Task.CompletedTask;
         }
 
@@ -575,6 +642,7 @@ namespace EasyRabbitFlow.Services
             }
 
             _ = TriggerRecoveryAsync();
+
             return Task.CompletedTask;
         }
 
@@ -588,6 +656,7 @@ namespace EasyRabbitFlow.Services
             }
 
             _ = TriggerRecoveryAsync();
+
             return Task.CompletedTask;
         }
 
@@ -632,6 +701,7 @@ namespace EasyRabbitFlow.Services
                     try
                     {
                         await EnsureConnectionAsync(_lifetimeCt);
+
                         await EnsureChannelAsync(_lifetimeCt);
 
                         _logger.LogInformation("[RABBIT-FLOW]: Consumer {Consumer} recovered after {Attempts} attempt(s).", _consumerType.Name, attempt);
@@ -659,12 +729,18 @@ namespace EasyRabbitFlow.Services
         private void DisposeChannel()
         {
             var ch = _channel;
+
             _channel = null;
-            if (ch == null) return;
+
+            if (ch == null)
+            {
+                return;
+            }
 
             try
             {
                 ch.CallbackExceptionAsync -= OnChannelCallbackExceptionAsync;
+
                 ch.ChannelShutdownAsync -= OnChannelShutdownAsync;
             }
             catch { }
@@ -675,33 +751,118 @@ namespace EasyRabbitFlow.Services
         private void DisposeConnection()
         {
             var conn = _connection;
+
             _connection = null;
-            if (conn == null) return;
+
+            if (conn == null)
+            {
+                return;
+            }
 
             try
             {
                 conn.ConnectionShutdownAsync -= OnConnectionShutdownAsync;
+                
                 conn.CallbackExceptionAsync -= OnConnectionCallbackExceptionAsync;
+                
                 conn.RecoverySucceededAsync -= OnRecoverySucceededAsync;
+                
                 conn.ConnectionRecoveryErrorAsync -= OnConnectionRecoveryErrorAsync;
             }
             catch { }
 
-            try { conn.Dispose(); } catch { }
+            try 
+            { 
+                conn.Dispose(); 
+            } 
+            catch { }
         }
 
         private static JsonElement? TryParseJsonElement(byte[]? body)
         {
-            if (body == null || body.Length == 0) return null;
+            if (body == null || body.Length == 0)
+            {
+                return null;
+            }
 
             try
             {
                 using var doc = JsonDocument.Parse(body);
+
                 return doc.RootElement.Clone();
             }
             catch
             {
                 return null;
+            }
+        }
+
+        private static readonly byte[] EnvelopeKey_MessageData = Encoding.UTF8.GetBytes("\"messageData\"");
+       
+        private static readonly byte[] EnvelopeKey_ExceptionType = Encoding.UTF8.GetBytes("\"exceptionType\"");
+
+        // Cheap byte-level fingerprint to decide whether a body is worth parsing as a DeadLetterEnvelope.
+        
+        // Scans for the two most distinctive envelope keys without touching JsonSerializer.
+        private static bool LooksLikeDeadLetterEnvelope(byte[]? body)
+        {
+            if (body == null || body.Length < 32)
+            {
+                return false;
+            }
+
+            int i = 0;
+
+            while (i < body.Length && (body[i] == (byte)' ' || body[i] == (byte)'\t' || body[i] == (byte)'\r' || body[i] == (byte)'\n'))
+            {
+                i++;
+            }
+
+            if (i >= body.Length || body[i] != (byte)'{')
+            {
+                return false;
+            }
+
+            var span = new ReadOnlySpan<byte>(body);
+
+            return span.IndexOf(EnvelopeKey_MessageData.AsSpan()) >= 0
+                && span.IndexOf(EnvelopeKey_ExceptionType.AsSpan()) >= 0;
+        }
+
+        private bool TryUnwrapDeadLetterEnvelope(byte[]? body, out byte[] innerBody, out DeadLetterEnvelope? envelope)
+        {
+            innerBody = body ?? Array.Empty<byte>();
+
+            envelope = null;
+
+            if (body == null || body.Length == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                envelope = JsonSerializer.Deserialize<DeadLetterEnvelope>(body, _serializerOptions);
+            }
+            catch
+            {
+                envelope = null;
+                return false;
+            }
+
+            if (envelope == null || envelope.MessageData == null || string.IsNullOrEmpty(envelope.ExceptionType))
+            {
+                return false;
+            }
+
+            try
+            {
+                innerBody = Encoding.UTF8.GetBytes(envelope.MessageData.Value.GetRawText());
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
     }

--- a/src/RabbitFlow/Services/RabbitFlowConfigurator.cs
+++ b/src/RabbitFlow/Services/RabbitFlowConfigurator.cs
@@ -104,6 +104,8 @@ namespace EasyRabbitFlow.Services
 
             settings.Invoke(consumerSettings);
 
+            consumerSettings.Validate();
+
 			_services.AddSingleton(consumerSettings);
 
 			var consumerType = typeof(TConsumer);

--- a/src/RabbitFlow/Settings/AutoGenerateSettings.cs
+++ b/src/RabbitFlow/Settings/AutoGenerateSettings.cs
@@ -26,12 +26,12 @@ namespace EasyRabbitFlow.Settings
         /// <summary>
         /// Gets or sets the name of the exchange to be generated.
         /// </summary>
-        public string? ExchangeName { get; set; } = null;
+        public string? ExchangeName { get; set; }
 
         /// <summary>
         /// Gets or sets the routing key for the exchange.
         /// </summary>
-        public string? RoutingKey { get; set; } = null;
+        public string? RoutingKey { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the exchange should be durable. Default is true.

--- a/src/RabbitFlow/Settings/ConsumerSettings.cs
+++ b/src/RabbitFlow/Settings/ConsumerSettings.cs
@@ -23,7 +23,11 @@ namespace EasyRabbitFlow.Settings
 
         bool AutoGenerate { get; set; }
 
+        bool DisableNameValidation { get; set; }
+
         bool ExtendDeadletterMessage { get; set; }
+
+        bool UnwrapDeadLetterEnvelopes { get; set; }
 
         ushort PrefetchCount { get; set; }
 
@@ -33,6 +37,8 @@ namespace EasyRabbitFlow.Settings
     public class ConsumerSettings<TConsumer> : IConsumerSettingsBase where TConsumer : class
     {
         private readonly IServiceCollection _services;
+
+        private AutoGenerateSettings<TConsumer>? _autoGenerateSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsumerSettings{TConsumer}"/> class.
@@ -87,16 +93,44 @@ namespace EasyRabbitFlow.Settings
         public bool AutoAckOnError { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to automatically generate necessary queue and exchange configurations. 
+        /// Gets or sets a value indicating whether to automatically generate necessary queue and exchange configurations.
         /// Default is false.
         /// </summary>
         public bool AutoGenerate { get; set; } = false;
 
         /// <summary>
-        ///  Gets or sets a value indicating whether to extend the dead-letter message with exception details. 
+        /// Gets or sets a value indicating whether to skip <c>RabbitFlowNameRules</c> validation against
+        /// reserved substrings (e.g. <c>deadletter</c>, <c>-exchange</c>, <c>-routing-key</c>) for the
+        /// queue name and any auto-generate exchange/routing-key names.
+        /// </summary>
+        /// <remarks>
+        /// Only takes effect when <see cref="AutoGenerate"/> is <c>false</c>. When the framework owns
+        /// topology generation it appends those reserved substrings to user-supplied names to derive
+        /// dead-letter queues, exchanges, and routing keys, so the validation must run regardless of
+        /// this flag. Setting this to <c>true</c> while <see cref="AutoGenerate"/> is also <c>true</c>
+        /// is silently ignored. Default is <c>false</c>.
+        /// </remarks>
+        public bool DisableNameValidation { get; set; } = false;
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether to extend the dead-letter message with exception details.
         ///  Default is true.
         /// </summary>
         public bool ExtendDeadletterMessage { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the consumer should defensively detect and unwrap a
+        /// <see cref="DeadLetterEnvelope"/> that arrives on the main queue (e.g. because a client manually
+        /// copied a message from the dead-letter queue back to the main queue, bypassing the
+        /// <see cref="DeadLetterReprocessSettings{TConsumer}">reprocessor</see>).
+        /// </summary>
+        /// <remarks>
+        /// Default is <c>false</c>. When <c>true</c>, every inbound message is fingerprinted with a cheap
+        /// byte-level scan; only when the fingerprint matches is the body parsed as a <c>DeadLetterEnvelope</c>
+        /// and the inner payload extracted. Prefer the dead-letter reprocessor over manual replay; this flag
+        /// only exists as a safety net for environments where manual replay can occur.
+        /// </remarks>
+        public bool UnwrapDeadLetterEnvelopes { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the number of messages that the consumer can prefetch.
@@ -140,6 +174,27 @@ namespace EasyRabbitFlow.Settings
             settings.Invoke(autoGenerateSettings);
 
             _services.AddSingleton(autoGenerateSettings);
+
+            _autoGenerateSettings = autoGenerateSettings;
+        }
+
+        // Validates queue name and any configured AutoGenerate names against RabbitFlowNameRules.
+        // Skipped only when DisableNameValidation is true AND AutoGenerate is false (the user fully
+        // owns the topology and reserved-substring suffixes the framework would append never apply).
+        internal void Validate()
+        {
+            if (DisableNameValidation && !AutoGenerate)
+            {
+                return;
+            }
+
+            RabbitFlowNameRules.Validate(QueueName, "queueName");
+
+            if (_autoGenerateSettings != null)
+            {
+                RabbitFlowNameRules.Validate(_autoGenerateSettings.ExchangeName, nameof(AutoGenerateSettings<TConsumer>.ExchangeName));
+                RabbitFlowNameRules.Validate(_autoGenerateSettings.RoutingKey, nameof(AutoGenerateSettings<TConsumer>.RoutingKey));
+            }
         }
 
 

--- a/src/RabbitFlow/Settings/RabbitFlowNameRules.cs
+++ b/src/RabbitFlow/Settings/RabbitFlowNameRules.cs
@@ -1,0 +1,33 @@
+using System;
+using EasyRabbitFlow.Exceptions;
+
+namespace EasyRabbitFlow.Settings
+{
+    internal static class RabbitFlowNameRules
+    {
+        private static readonly string[] ReservedSubstrings = new[]
+        {
+            "deadletter",
+            "-exchange",
+            "-routing-key"
+        };
+
+        public static void Validate(string? name, string paramName)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            foreach (var reserved in ReservedSubstrings)
+            {
+                if (name!.IndexOf(reserved, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    throw new RabbitFlowException(
+                        $"{paramName} '{name}' contains the reserved substring '{reserved}'. " +
+                        $"The framework appends these substrings when auto-generating topology, so they cannot appear in user-supplied names. Reserved: {string.Join(", ", ReservedSubstrings)}.");
+                }
+            }
+        }
+    }
+}

--- a/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
+++ b/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using EasyRabbitFlow.Services;
+using EasyRabbitFlow.Settings;
 using EasyRabbitFlow.Tests.Fixtures;
 using EasyRabbitFlow.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -234,6 +235,240 @@ public class ConsumerTests
         Assert.Equal(10, TestConsumer.ReceivedMessages.Count);
 
         // Cleanup
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consumer_WrappedDeadLetterEnvelope_DefaultSetting_DoesNotUnwrap()
+    {
+        // Arrange - same scenario as the unwrap test, but the opt-in flag is left at its default (false).
+        // Expectation: the envelope is NOT detected; the body deserializes as a default TestEvent
+        // (envelope keys don't map to TestEvent), and the consumer receives it with null Id/Message.
+        TestConsumer.Reset();
+
+        var queueName = $"test-no-unwrap-default-{Guid.NewGuid():N}";
+
+        var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
+        {
+            settings.AddConsumer<TestConsumer>(queueName, cfg =>
+            {
+                cfg.AutoGenerate = true;
+                cfg.PrefetchCount = 1;
+                cfg.Timeout = TimeSpan.FromSeconds(10);
+                // UnwrapDeadLetterEnvelopes NOT set - default is false.
+                cfg.ConfigureAutoGenerate(ag =>
+                {
+                    ag.GenerateExchange = false;
+                    ag.GenerateDeadletterQueue = false;
+                    ag.DurableQueue = false;
+                    ag.AutoDeleteQueue = true;
+                });
+            });
+        });
+
+        var hostedService = sp.GetServices<IHostedService>().First();
+        await hostedService.StartAsync(CancellationToken.None);
+        await Task.Delay(500);
+
+        var jsonOpts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        var inner = new TestEvent { Id = "would-be-unwrapped", Message = "would-be-payload" };
+        var innerJson = JsonSerializer.Serialize(inner, jsonOpts);
+
+        var envelope = new DeadLetterEnvelope
+        {
+            DateUtc = DateTime.UtcNow,
+            MessageType = nameof(TestEvent),
+            MessageData = JsonSerializer.Deserialize<JsonElement>(innerJson),
+            ExceptionType = "InvalidOperationException",
+            ErrorMessage = "previous failure",
+            ReprocessAttempts = 0
+        };
+
+        var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, jsonOpts));
+
+        using var conn = await _fixture.CreateDirectConnectionAsync();
+        using var ch = await conn.CreateChannelAsync();
+        await ch.BasicPublishAsync("", queueName, body);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (TestConsumer.ReceivedMessages.Count == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100);
+        }
+
+        // With the flag off, no unwrap fires. The envelope's top-level keys don't map to TestEvent's
+        // properties, so deserialization yields a TestEvent with its property defaults intact -
+        // explicitly NOT the inner payload's values.
+        Assert.Single(TestConsumer.ReceivedMessages);
+        Assert.NotEqual("would-be-unwrapped", TestConsumer.ReceivedMessages[0].Id);
+        Assert.NotEqual("would-be-payload", TestConsumer.ReceivedMessages[0].Message);
+
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consumer_WrappedDeadLetterEnvelope_IsUnwrappedAndProcessed()
+    {
+        // Arrange - simulates a client manually replaying a DeadLetterEnvelope from the DLQ to the main queue.
+        TestConsumer.Reset();
+
+        var queueName = $"test-unwrap-{Guid.NewGuid():N}";
+
+        var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
+        {
+            settings.AddConsumer<TestConsumer>(queueName, cfg =>
+            {
+                cfg.AutoGenerate = true;
+                cfg.PrefetchCount = 1;
+                cfg.Timeout = TimeSpan.FromSeconds(10);
+                cfg.UnwrapDeadLetterEnvelopes = true;
+                cfg.ConfigureAutoGenerate(ag =>
+                {
+                    ag.GenerateExchange = false;
+                    ag.GenerateDeadletterQueue = false;
+                    ag.DurableQueue = false;
+                    ag.AutoDeleteQueue = true;
+                });
+            });
+        });
+
+        var hostedService = sp.GetServices<IHostedService>().First();
+        await hostedService.StartAsync(CancellationToken.None);
+        await Task.Delay(500);
+
+        var jsonOpts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        var inner = new TestEvent { Id = "unwrap-1", Message = "wrapped-payload" };
+        var innerJson = JsonSerializer.Serialize(inner, jsonOpts);
+
+        var envelope = new DeadLetterEnvelope
+        {
+            DateUtc = DateTime.UtcNow,
+            MessageType = nameof(TestEvent),
+            MessageId = "msg-from-envelope",
+            CorrelationId = "corr-from-envelope",
+            MessageData = JsonSerializer.Deserialize<JsonElement>(innerJson),
+            ExceptionType = "InvalidOperationException",
+            ErrorMessage = "previous failure",
+            ReprocessAttempts = 0
+        };
+
+        var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, jsonOpts));
+
+        // Act - publish the wrapped envelope directly to the main queue.
+        using var conn = await _fixture.CreateDirectConnectionAsync();
+        using var ch = await conn.CreateChannelAsync();
+        await ch.BasicPublishAsync("", queueName, body);
+
+        // Assert - the consumer extracts the inner payload and processes it.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (TestConsumer.ReceivedMessages.Count == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100);
+        }
+
+        Assert.Single(TestConsumer.ReceivedMessages);
+        Assert.Equal("unwrap-1", TestConsumer.ReceivedMessages[0].Id);
+        Assert.Equal("wrapped-payload", TestConsumer.ReceivedMessages[0].Message);
+
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consumer_WrappedEnvelope_HandlerFails_DeadLetterDoesNotDoubleWrap()
+    {
+        // Arrange - a wrapped envelope is replayed to the main queue, but the consumer always fails.
+        // The new DLQ entry must wrap the ORIGINAL payload (depth 1), not the inbound envelope (depth 2).
+        AlwaysFailConsumer.Reset();
+
+        var queueName = $"test-no-double-{Guid.NewGuid():N}";
+        var dlqName = $"{queueName}-deadletter";
+
+        var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
+        {
+            settings.AddConsumer<AlwaysFailConsumer>(queueName, cfg =>
+            {
+                cfg.AutoGenerate = true;
+                cfg.PrefetchCount = 1;
+                cfg.Timeout = TimeSpan.FromSeconds(5);
+                cfg.ExtendDeadletterMessage = true;
+                cfg.UnwrapDeadLetterEnvelopes = true;
+                cfg.ConfigureAutoGenerate(ag =>
+                {
+                    ag.GenerateExchange = false;
+                    ag.GenerateDeadletterQueue = true;
+                    ag.DurableQueue = false;
+                    ag.DurableExchange = false;
+                    ag.AutoDeleteQueue = true;
+                });
+            });
+        });
+
+        var hostedService = sp.GetServices<IHostedService>().First();
+        await hostedService.StartAsync(CancellationToken.None);
+        await Task.Delay(500);
+
+        var jsonOpts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        var inner = new TestEvent { Id = "no-double-1", Message = "should-be-unwrapped" };
+        var innerJson = JsonSerializer.Serialize(inner, jsonOpts);
+
+        var envelope = new DeadLetterEnvelope
+        {
+            DateUtc = DateTime.UtcNow,
+            MessageType = nameof(TestEvent),
+            MessageData = JsonSerializer.Deserialize<JsonElement>(innerJson),
+            ExceptionType = "InvalidOperationException",
+            ErrorMessage = "old-error",
+            ReprocessAttempts = 0
+        };
+
+        var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(envelope, jsonOpts));
+
+        // Act
+        using var conn = await _fixture.CreateDirectConnectionAsync();
+        using var ch = await conn.CreateChannelAsync();
+        await ch.BasicPublishAsync("", queueName, body);
+
+        // Wait until the message lands in the DLQ.
+        BasicGetResult? dlqResult = null;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            dlqResult = await ch.BasicGetAsync(dlqName, autoAck: true);
+            if (dlqResult != null) break;
+            await Task.Delay(200);
+        }
+
+        // Assert - the consumer received the unwrapped TestEvent (proof unwrap fired).
+        Assert.Single(AlwaysFailConsumer.ReceivedMessages);
+        Assert.Equal("no-double-1", AlwaysFailConsumer.ReceivedMessages[0].Id);
+
+        // The DLQ entry exists.
+        Assert.NotNull(dlqResult);
+
+        var dlqEnvelope = JsonSerializer.Deserialize<DeadLetterEnvelope>(dlqResult!.Body.Span, jsonOpts);
+        Assert.NotNull(dlqEnvelope);
+        Assert.NotNull(dlqEnvelope!.MessageData);
+
+        // Critical: the DLQ envelope's MessageData is the original TestEvent JSON, not a nested envelope.
+        var msgData = dlqEnvelope.MessageData!.Value;
+        Assert.Equal(JsonValueKind.Object, msgData.ValueKind);
+
+        Assert.True(msgData.TryGetProperty("id", out var idProp), "DLQ envelope should wrap the original TestEvent (with 'id'), not a nested envelope.");
+        Assert.Equal("no-double-1", idProp.GetString());
+
+        Assert.True(msgData.TryGetProperty("message", out var msgProp));
+        Assert.Equal("should-be-unwrapped", msgProp.GetString());
+
+        // And it must NOT carry envelope-level fields (which would indicate double-wrapping).
+        Assert.False(msgData.TryGetProperty("messageData", out _));
+        Assert.False(msgData.TryGetProperty("exceptionType", out _));
+
+        // Sanity: the new envelope should reflect the FRESH failure, not the inbound one.
+        Assert.NotEqual("old-error", dlqEnvelope.ErrorMessage);
+
         await hostedService.StopAsync(CancellationToken.None);
     }
 }

--- a/tests/EasyRabbitFlow.Tests/Helpers/TestTypes.cs
+++ b/tests/EasyRabbitFlow.Tests/Helpers/TestTypes.cs
@@ -28,6 +28,24 @@ public class TestConsumer : IRabbitFlowConsumer<TestEvent>
     }
 }
 
+public class AlwaysFailConsumer : IRabbitFlowConsumer<TestEvent>
+{
+    private static readonly ConcurrentBag<TestEvent> _received = new();
+
+    public static IReadOnlyList<TestEvent> ReceivedMessages => _received.ToList();
+
+    public Task HandleAsync(TestEvent message, RabbitFlowMessageContext context, CancellationToken cancellationToken)
+    {
+        _received.Add(message);
+        throw new InvalidOperationException("AlwaysFailConsumer: intentional failure");
+    }
+
+    public static void Reset()
+    {
+        _received.Clear();
+    }
+}
+
 public class TransientFailConsumer : IRabbitFlowConsumer<TestEvent>
 {
     private static int _callCount;

--- a/tests/EasyRabbitFlow.Tests/NameValidationTests.cs
+++ b/tests/EasyRabbitFlow.Tests/NameValidationTests.cs
@@ -1,0 +1,150 @@
+using EasyRabbitFlow.Exceptions;
+using EasyRabbitFlow.Services;
+using EasyRabbitFlow.Settings;
+using EasyRabbitFlow.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasyRabbitFlow.Tests;
+
+public class NameValidationTests
+{
+    private static void AddTestConsumer(string queueName, Action<ConsumerSettings<TestConsumer>>? configure = null)
+    {
+        var configurator = new RabbitFlowConfigurator(new ServiceCollection());
+
+        configurator.AddConsumer<TestConsumer>(queueName, cfg => configure?.Invoke(cfg));
+    }
+
+    [Theory]
+    [InlineData("orders-deadletter")]
+    [InlineData("orders-deadletter-extra")]
+    [InlineData("my-exchange")]
+    [InlineData("my-exchange-suffix")]
+    [InlineData("my-routing-key")]
+    [InlineData("queue-routing-key-extra")]
+    public void ConsumerSettings_QueueName_WithReservedSubstring_Throws(string queueName)
+    {
+        var ex = Assert.Throws<RabbitFlowException>(() => AddTestConsumer(queueName));
+
+        Assert.Contains(queueName, ex.Message);
+        Assert.Contains("reserved", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("orders-DEADLETTER")]
+    [InlineData("Orders-DeadLetter")]
+    [InlineData("queue-Exchange")]
+    [InlineData("QUEUE-ROUTING-KEY")]
+    public void ConsumerSettings_QueueName_ReservedSubstring_IsCaseInsensitive(string queueName)
+    {
+        Assert.Throws<RabbitFlowException>(() => AddTestConsumer(queueName));
+    }
+
+    [Theory]
+    [InlineData("orders")]
+    [InlineData("orders-created")]
+    [InlineData("user.signed-up")]
+    public void ConsumerSettings_QueueName_ValidName_DoesNotThrow(string queueName)
+    {
+        AddTestConsumer(queueName);
+    }
+
+    [Theory]
+    [InlineData("orders-deadletter")]
+    [InlineData("custom-exchange")]
+    [InlineData("custom-routing-key")]
+    public void AutoGenerateSettings_ExchangeName_WithReservedSubstring_Throws(string exchangeName)
+    {
+        var ex = Assert.Throws<RabbitFlowException>(() => AddTestConsumer("orders", cfg =>
+        {
+            cfg.AutoGenerate = true;
+            cfg.ConfigureAutoGenerate(ag => ag.ExchangeName = exchangeName);
+        }));
+
+        Assert.Contains(exchangeName, ex.Message);
+    }
+
+    [Theory]
+    [InlineData("orders-deadletter")]
+    [InlineData("rk-exchange")]
+    [InlineData("rk-routing-key")]
+    public void AutoGenerateSettings_RoutingKey_WithReservedSubstring_Throws(string routingKey)
+    {
+        var ex = Assert.Throws<RabbitFlowException>(() => AddTestConsumer("orders", cfg =>
+        {
+            cfg.AutoGenerate = true;
+            cfg.ConfigureAutoGenerate(ag => ag.RoutingKey = routingKey);
+        }));
+
+        Assert.Contains(routingKey, ex.Message);
+    }
+
+    [Fact]
+    public void AutoGenerateSettings_NullOrWhitespace_DoesNotThrow()
+    {
+        AddTestConsumer("orders", cfg =>
+        {
+            cfg.AutoGenerate = true;
+            cfg.ConfigureAutoGenerate(ag =>
+            {
+                ag.ExchangeName = null;
+                ag.RoutingKey = null;
+            });
+        });
+
+        AddTestConsumer("orders", cfg =>
+        {
+            cfg.AutoGenerate = true;
+            cfg.ConfigureAutoGenerate(ag =>
+            {
+                ag.ExchangeName = "   ";
+                ag.RoutingKey = "";
+            });
+        });
+    }
+
+    [Fact]
+    public void AutoGenerateSettings_ValidNames_DoNotThrow()
+    {
+        AddTestConsumer("orders", cfg =>
+        {
+            cfg.AutoGenerate = true;
+            cfg.ConfigureAutoGenerate(ag =>
+            {
+                ag.ExchangeName = "orders.events";
+                ag.RoutingKey = "orders.created";
+            });
+        });
+    }
+
+    [Theory]
+    [InlineData("orders-deadletter")]
+    [InlineData("my-exchange")]
+    [InlineData("my-routing-key")]
+    public void DisableNameValidation_WithAutoGenerateOff_AllowsReservedSubstring(string queueName)
+    {
+        AddTestConsumer(queueName, cfg =>
+        {
+            cfg.DisableNameValidation = true;
+            cfg.AutoGenerate = false;
+        });
+    }
+
+    [Fact]
+    public void DisableNameValidation_IsIgnored_WhenAutoGenerateIsOn()
+    {
+        var ex = Assert.Throws<RabbitFlowException>(() => AddTestConsumer("orders-deadletter", cfg =>
+        {
+            cfg.DisableNameValidation = true;
+            cfg.AutoGenerate = true;
+        }));
+
+        Assert.Contains("orders-deadletter", ex.Message);
+    }
+
+    [Fact]
+    public void DisableNameValidation_DefaultsToFalse_StillValidatesQueueName()
+    {
+        Assert.Throws<RabbitFlowException>(() => AddTestConsumer("orders-deadletter"));
+    }
+}


### PR DESCRIPTION
   New consumer settings
   - UnwrapDeadLetterEnvelopes (default false) — opt-in safety net for messages that arrive on the main queue already wrapped in a DeadLetterEnvelope (typical of manual DLQ replays via Shovel, management UI, or ad-hoc scripts). A cheap byte-level fingerprint detects the envelope shape; only on a match does the consumer parse and unwrap, surfacing the original MessageId/CorrelationId via RabbitFlowMessageContext when AMQP didn't already provide them. If the unwrapped message fails again, the new DLQ entry wraps the original payload (depth 1), preventing nested envelopes from accumulating across replays.
   - DisableNameValidation (default false) — escape hatch for the new reserved-substring validation. Only honored when AutoGenerate is false, because the framework still needs to append reserved suffixes to derive DLQ topology when it owns generation.

   Reserved-substring validation
   - New internal RabbitFlowNameRules.Validate runs on every consumer registration. Rejects queueName, AutoGenerate.ExchangeName, and AutoGenerate.RoutingKey if they contain "deadletter", "-exchange", or "-routing-key" (case-insensitive), since the framework appends those substrings when auto-generating topology and overlapping user-supplied names would produce ambiguous queue/exchange names. Existing deployments that happen to use these substrings in custom queue names will fail at registration after upgrading; set DisableNameValidation = true (with AutoGenerate = false) to keep the legacy name.

   Other
   - ConsumerHostedService default JsonSerializerOptions fallback is now JsonSerializerOptions.Web (camelCase + case-insensitive), matching ASP.NET Core defaults. Behavior is equivalent for camelCase payloads; deserialization is now case-insensitive by default.

   Sample
   - RabbitFlowSample turns on UnwrapDeadLetterEnvelopes for the orders consumer to demonstrate the new safety net.

   Tests
   - ConsumerTests covers three cases: unwrap fires, default-off does NOT unwrap, and re-failure of an unwrapped message produces a depth-1 DLQ envelope (no double-wrap).
   - NameValidationTests covers reserved-substring detection, case-insensitivity, valid names, the DisableNameValidation escape hatch, and the AutoGenerate-on guardrail that ignores the flag.

   Docs
   - README adds Reserved Name Substrings and Manual DLQ Replay Safety Net subsections, updates the consumer settings table with the two

   Docs
   - README adds Reserved Name Substrings and Manual DLQ Replay Safety Net subsections, updates the consumer settings table with the two new flags, and corrects the JSON-defaults note to mention JsonSerializerOptions.Web.

   - Version bumped to 6.0.2.