### PR TITLE
fix: survive stale auto-delete queues and own consumer recovery (v8.0…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,9 +35,8 @@ cfg.ConfigureHost(host =>
 | `Username` | string | `"guest"` | Authentication username |
 | `Password` | string | `"guest"` | Authentication password |
 | `VirtualHost` | string | `"/"` | RabbitMQ virtual host |
-| `AutomaticRecoveryEnabled` | bool | `true` | Auto-reconnect after failures |
-| `TopologyRecoveryEnabled` | bool | `true` | Auto-recover queues/exchanges after reconnect |
-| `NetworkRecoveryInterval` | TimeSpan | `10s` | Wait time between recovery attempts |
+| `AutomaticRecoveryEnabled` | bool | `true` | Enables EasyRabbitFlow's own consumer recovery (re-connects, re-creates the channel and re-declares the full topology on an unexpected shutdown). The RabbitMQ client's built-in recovery is always disabled to avoid running two recovery systems at once. |
+| `NetworkRecoveryInterval` | TimeSpan | `10s` | Base delay for the library's recovery backoff (exponential from this value, capped at 30s) |
 | `RequestedHeartbeat` | TimeSpan | `30s` | Heartbeat interval for connection health |
 
 ### JSON Serialization

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -241,15 +241,26 @@ The value is floored at 60s because RabbitMQ rejects consumer timeouts below one
 >
 > Unlike most queue arguments, RabbitMQ treats `x-consumer-timeout` as *optional* and **silently ignores a changed value when an existing queue is redeclared** — no `PRECONDITION_FAILED`, no error, no warning. So if you change `Timeout`, `MaxRetryCount`, or `RetryInterval` on a queue that already exists, the new `x-consumer-timeout` is **not** applied: the queue keeps its original value. **To make the change take effect, delete and recreate the queue** (or apply a [`consumer-timeout` policy](https://www.rabbitmq.com/docs/consumers#per-queue-delivery-timeout) on the broker, which *can* be changed in place). This is specific to `x-consumer-timeout`; other arguments (`x-dead-letter-exchange`, `x-max-priority`, custom `Args`) **are** verified on redeclare — see the **Queue arguments are immutable in RabbitMQ** note below.
 
-**Channel recovery**
+**Channel & connection recovery**
 
-If the broker does close a channel (timeout exceeded, protocol violation, etc.), EasyRabbitFlow automatically recreates the channel, re-applies QoS, and re-subscribes the consumer — with exponential backoff between attempts (1s, 2s, 4s… capped at 30s). Connection-level closures are handled the same way.
+EasyRabbitFlow manages consumer recovery itself rather than relying on the RabbitMQ client's built-in automatic/topology recovery (which is deliberately disabled on the connections it owns — running both at once makes the client re-bind/re-consume a recorded topology that doesn't include the main queue, surfacing as a `404 NOT_FOUND` on reconnect). When the broker closes a channel or connection (timeout exceeded, protocol violation, network blip, etc.), the consumer re-establishes the connection and channel, re-applies QoS, **re-declares its full topology**, and re-subscribes — with exponential backoff between attempts, seeded by `NetworkRecoveryInterval` (e.g. 10s, 20s, 40s… capped at 30s, or the configured value when larger).
+
+This is controlled by two `HostSettings` knobs:
+
+- `AutomaticRecoveryEnabled` (default `true`) — when `false`, a dropped consumer stays down until the application restarts.
+- `NetworkRecoveryInterval` (default `10s`) — the base delay for the recovery backoff.
+
+See [Configuration](configuration.md#host-settings).
 
 > **⚠️ Queue arguments are immutable in RabbitMQ**
 >
 > Arguments that RabbitMQ verifies for equivalence — `x-dead-letter-exchange`, `x-dead-letter-routing-key`, `x-message-ttl`, `x-max-length`, `x-max-priority`, `durable`, and any custom `Args` — cannot be changed by redeclaring an existing queue: the broker rejects the declare with `PRECONDITION_FAILED`. (The derived `x-consumer-timeout` is the exception — it is silently *ignored* rather than rejected; see the note above.)
 >
-> EasyRabbitFlow does **not** fail the consumer over this. It declares the queue on a throwaway channel, and if RabbitMQ rejects it with `PRECONDITION_FAILED`, the consumer **adopts the existing queue as-is and keeps running**, logging a warning that names the queue — a running consumer is safer than one that won't start and silently leaves the system idle. To actually apply the new arguments:
+> EasyRabbitFlow does **not** fail the consumer over this. It declares the queue on a throwaway channel, and if RabbitMQ rejects it with `PRECONDITION_FAILED`, the consumer **adopts the existing queue as-is and keeps running**, logging a warning that names the queue — a running consumer is safer than one that won't start and silently leaves the system idle.
+>
+> A related edge case is handled too: if the existing queue is a **stale `auto-delete` (or `x-expires`) queue** left over from a previous run — for example a broker that survived an app restart, as is common with Aspire — the broker may delete it the moment its previous consumer disconnects, *right as the new consumer is starting*. That produces an "adopt" (the queue still exists at declare time) immediately followed by a `404 NOT_FOUND` when binding/consuming (it's already gone). The consumer detects the 404 during setup, **recreates the queue with the current arguments** (it no longer exists, so there is no mismatch) and resumes — rather than crashing host startup.
+>
+> To actually apply the new arguments to a queue that *does* persist:
 >
 > **Options:**
 >

--- a/sample/RabbitFlowSample/Program.cs
+++ b/sample/RabbitFlowSample/Program.cs
@@ -75,7 +75,6 @@ builder.Services.AddRabbitFlow(settings =>
         }
 
         host.AutomaticRecoveryEnabled = true;
-        host.TopologyRecoveryEnabled = true;
     });
 
     settings.ConfigurePublisher(pub =>

--- a/src/RabbitFlow/EasyRabbitFlow.csproj
+++ b/src/RabbitFlow/EasyRabbitFlow.csproj
@@ -6,7 +6,7 @@
 		<Title>EasyRabbitFlow</Title>
 		<Authors>Juan Carlos Torres Cuervo</Authors>
 		<Description>EasyRabbitFlow: high-performance RabbitMQ client for .NET. Fluent configuration, optional topology (queue/exchange/dead-letter) generation, reflection-free consumers, configurable retry (exponential/backoff), custom dead-letter routing, temporary batch processing, queue state helpers. Targets .NET Standard 2.1 and .NET 8.</Description>
-		<Version>8.0.0-rc.1</Version>
+		<Version>8.0.0-rc.2</Version>
 		<PackageTags>rabbitmq;dotnet;messaging;queue;consumer;publisher;retry;deadletter;backoff;temporary;batch</PackageTags>
 		<PackageProjectUrl>https://github.com/devjuanca/EasyRabbitFlow</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/devjuanca/EasyRabbitFlow</RepositoryUrl>

--- a/src/RabbitFlow/Services/ConsumerHostedService.cs
+++ b/src/RabbitFlow/Services/ConsumerHostedService.cs
@@ -47,6 +47,8 @@ namespace EasyRabbitFlow.Services
 
             var serializerOptions = _root.GetKeyedService<JsonSerializerOptions>("RabbitFlowJsonSerializer") ?? JsonSerializerOptions.Web;
 
+            var hostSettings = _root.GetService<HostSettings>() ?? new HostSettings();
+
             foreach (var marker in markers)
             {
                 var settingsObj = marker.SettingsInstance;
@@ -63,7 +65,7 @@ namespace EasyRabbitFlow.Services
                     continue;
                 }
 
-                var instance = new ConsumerInstance(_root, _logger, connectionFactory, serializerOptions, marker);
+                var instance = new ConsumerInstance(_root, _logger, connectionFactory, serializerOptions, hostSettings, marker);
 
                 _instances.Add(instance);
 
@@ -112,6 +114,8 @@ namespace EasyRabbitFlow.Services
         private readonly int _rpMax;
         private readonly int _totalAttempts;
         private readonly int _rpInterval;
+        private readonly bool _recoveryEnabled;
+        private readonly int _recoveryBaseDelayMs;
         private readonly object? _autoGenObj;
         private readonly long _serverConsumerTimeoutMs;
         private readonly SemaphoreSlim _channelGate = new SemaphoreSlim(1, 1);
@@ -132,6 +136,7 @@ namespace EasyRabbitFlow.Services
         private string _deadLetterExchangeName = string.Empty;
         private string _deadLetterRoutingKey = string.Empty;
         private volatile bool _stopping;
+        private volatile bool _rebuilding;
         private int _stopped;
         private CancellationToken _lifetimeCt;
 
@@ -140,6 +145,7 @@ namespace EasyRabbitFlow.Services
             ILogger logger,
             ConnectionFactory connectionFactory,
             JsonSerializerOptions serializerOptions,
+            HostSettings hostSettings,
             IConsumerSettingsMarker marker)
         {
             _root = root;
@@ -147,6 +153,12 @@ namespace EasyRabbitFlow.Services
             _connectionFactory = connectionFactory;
             _serializerOptions = serializerOptions;
             _marker = marker;
+
+            _recoveryEnabled = hostSettings.AutomaticRecoveryEnabled;
+
+            // Base delay for the library's own recovery backoff; floored at 1s so a misconfigured tiny interval
+            // never spins the recovery loop. See HostSettings.NetworkRecoveryInterval.
+            _recoveryBaseDelayMs = (int)Math.Max(1000, hostSettings.NetworkRecoveryInterval.TotalMilliseconds);
 
             var settings = marker.SettingsInstance;
 
@@ -230,9 +242,30 @@ namespace EasyRabbitFlow.Services
         {
             _lifetimeCt = cancellationToken;
 
-            await EnsureConnectionAsync(cancellationToken);
+            try
+            {
+                await EnsureConnectionAsync(cancellationToken);
 
-            await EnsureChannelAsync(cancellationToken);
+                await EnsureChannelAsync(cancellationToken);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // A consumer that fails to set up (topology declare, bind, consume) must not bring the whole host
+                // down at startup: one broken consumer should not leave the entire application unable to start.
+                // Log it and, when recovery is enabled, keep retrying in the background; otherwise the consumer
+                // stays down but the host comes up.
+                _logger.LogError(ex,
+                    "[RABBIT-FLOW]: Initial setup failed for {Consumer}. The host will continue to start. {Recovery}",
+                    _consumerType.Name,
+                    _recoveryEnabled
+                        ? "Recovery is enabled; the consumer will keep retrying in the background."
+                        : "Recovery is disabled (AutomaticRecoveryEnabled = false); the consumer stays down until restart.");
+
+                if (_recoveryEnabled)
+                {
+                    _ = TriggerRecoveryAsync();
+                }
+            }
         }
 
         public async Task StopAsync(CancellationToken cancellationToken = default)
@@ -296,6 +329,12 @@ namespace EasyRabbitFlow.Services
                 return;
             }
 
+            // The connection is gone, so any channel on it is dead too — even though a stale IChannel can keep
+            // reporting IsOpen == true for a while after its connection drops. Drop it here so EnsureChannelAsync
+            // rebuilds the channel AND re-attaches the consumer on the new connection instead of short-circuiting
+            // on the stale flag and leaving the queue with no consumer.
+            DisposeChannel();
+
             DisposeConnection();
 
             _connection = await _connectionFactory.CreateConnectionAsync($"consumer_{_consumerId}", ct);
@@ -318,42 +357,78 @@ namespace EasyRabbitFlow.Services
 
             DisposeChannel();
 
-            _channel = await _connection!.CreateChannelAsync(ConfirmChannelOptions, cancellationToken: ct);
+            // Bounded retry around topology declaration + consume. The auto-generated main queue can be present
+            // when we declare/adopt it (on the throwaway channel) but already gone by the time we bind/consume it
+            // on this channel — e.g. an auto-delete queue whose previous consumer just disconnected, or an
+            // x-expires queue — which surfaces as a 404 that closes the channel. On that race we recreate the
+            // channel and retry: the next pass finds the queue missing and re-creates it with the current arguments
+            // (so there is no longer a mismatch), then binds and consumes. Recovery is suppressed while we rebuild
+            // so a channel-close during setup can't kick off a second, racing recovery on top of this loop.
+            const int maxAttempts = 3;
 
-            _channel.CallbackExceptionAsync += OnChannelCallbackExceptionAsync;
-            
-            _channel.ChannelShutdownAsync += OnChannelShutdownAsync;
+            _rebuilding = true;
 
-            await _channel.BasicQosAsync(0, _prefetch, false, ct);
-
-            if (_autoGenerate && _autoGenObj != null)
+            try
             {
-                await DeclareTopologyAsync(_channel, ct);
+                for (int attempt = 1; ; attempt++)
+                {
+                    _channel = await _connection!.CreateChannelAsync(ConfirmChannelOptions, cancellationToken: ct);
+
+                    _channel.CallbackExceptionAsync += OnChannelCallbackExceptionAsync;
+
+                    _channel.ChannelShutdownAsync += OnChannelShutdownAsync;
+
+                    await _channel.BasicQosAsync(0, _prefetch, false, ct);
+
+                    try
+                    {
+                        if (_autoGenerate && _autoGenObj != null)
+                        {
+                            await DeclareTopologyAsync(_channel, ct);
+                        }
+
+                        var consumer = new AsyncEventingBasicConsumer(_channel);
+
+                        consumer.ReceivedAsync += async (_, ea) =>
+                        {
+                            if (_stopping || _lifetimeCt.IsCancellationRequested)
+                            {
+                                return;
+                            }
+                            try
+                            {
+                                await _prefetchSemaphore.WaitAsync(_lifetimeCt);
+                            }
+                            catch { return; }
+
+                            if (_stopping || _lifetimeCt.IsCancellationRequested)
+                            {
+                                return;
+                            }
+
+                            _ = ProcessMessageAsync(ea);
+                        };
+
+                        await _channel.BasicConsumeAsync(queue: _queueName, autoAck: false, consumer: consumer, cancellationToken: ct);
+
+                        return;
+                    }
+                    catch (OperationInterruptedException ex) when (attempt < maxAttempts && ex.ShutdownReason?.ReplyCode == 404)
+                    {
+                        _logger.LogWarning(
+                            "[RABBIT-FLOW]: Queue '{Queue}' for {Consumer} was deleted by the broker during setup (404 NOT_FOUND) — " +
+                            "typically a stale auto-delete or x-expires queue whose previous consumer had just disconnected. " +
+                            "Recreating it with the current arguments and retrying (attempt {Attempt}/{Max}).",
+                            _queueName, _consumerType.Name, attempt, maxAttempts);
+
+                        DisposeChannel();
+                    }
+                }
             }
-
-            var consumer = new AsyncEventingBasicConsumer(_channel);
-
-            consumer.ReceivedAsync += async (_, ea) =>
+            finally
             {
-                if (_stopping || _lifetimeCt.IsCancellationRequested)
-                {
-                    return;
-                }
-                try
-                {
-                    await _prefetchSemaphore.WaitAsync(_lifetimeCt);
-                }
-                catch { return; }
-
-                if (_stopping || _lifetimeCt.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                _ = ProcessMessageAsync(ea);
-            };
-
-            await _channel.BasicConsumeAsync(queue: _queueName, autoAck: false, consumer: consumer, cancellationToken: ct);
+                _rebuilding = false;
+            }
         }
 
         private async Task DeclareTopologyAsync(IChannel channel, CancellationToken ct)
@@ -929,7 +1004,7 @@ namespace EasyRabbitFlow.Services
         {
             _logger.LogWarning("[RABBIT-FLOW]: Channel shutdown for {Consumer}. ReplyCode: {Code}, ReplyText: {Text}", _consumerType.Name, args.ReplyCode, args.ReplyText);
 
-            if (_stopping || args.Initiator == ShutdownInitiator.Application)
+            if (_stopping || _rebuilding || !_recoveryEnabled || args.Initiator == ShutdownInitiator.Application)
             {
                 return Task.CompletedTask;
             }
@@ -943,7 +1018,7 @@ namespace EasyRabbitFlow.Services
         {
             _logger.LogWarning("[RABBIT-FLOW]: Connection shutdown for {Consumer}. ReplyCode: {Code}, ReplyText: {Text}", _consumerType.Name, args.ReplyCode, args.ReplyText);
 
-            if (_stopping || args.Initiator == ShutdownInitiator.Application)
+            if (_stopping || _rebuilding || !_recoveryEnabled || args.Initiator == ShutdownInitiator.Application)
             {
                 return Task.CompletedTask;
             }
@@ -973,7 +1048,7 @@ namespace EasyRabbitFlow.Services
 
         private async Task TriggerRecoveryAsync()
         {
-            if (_stopping)
+            if (_stopping || !_recoveryEnabled)
             {
                 return;
             }
@@ -1006,7 +1081,8 @@ namespace EasyRabbitFlow.Services
                     }
                     catch (Exception ex)
                     {
-                        var delay = Math.Min(1000 * (int)Math.Pow(2, Math.Min(attempt, 6)), 30_000);
+                        var cap = Math.Max(30_000, _recoveryBaseDelayMs);
+                        var delay = Math.Min(_recoveryBaseDelayMs * (int)Math.Pow(2, Math.Min(attempt - 1, 6)), cap);
                         _logger.LogError(ex, "[RABBIT-FLOW]: Recovery attempt {Attempt} failed for {Consumer}. Retrying in {Delay}ms.", attempt, _consumerType.Name, delay);
 
                         try { await Task.Delay(delay, _lifetimeCt); } catch { return; }
@@ -1064,11 +1140,16 @@ namespace EasyRabbitFlow.Services
             }
             catch { }
 
-            try 
-            { 
-                conn.Dispose(); 
-            } 
-            catch { }
+            // Disposing a connection that the broker force-closed (or that died mid-flight) blocks the caller for
+            // up to the client's ContinuationTimeout (20s by default) while it waits for a close-ok that never
+            // arrives. Offload it so recovery and shutdown aren't stalled; a healthy connection still disposes
+            // promptly, just off the calling path.
+            var connToDispose = conn;
+
+            _ = Task.Run(() =>
+            {
+                try { connToDispose.Dispose(); } catch { }
+            });
         }
 
         private static JsonElement? TryParseJsonElement(byte[]? body)

--- a/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
+++ b/src/RabbitFlow/Services/IRabbitFlowPublisher.cs
@@ -417,19 +417,33 @@ namespace EasyRabbitFlow.Services
 
         private async Task<IConnection> ResolveConnection(string connectionId, CancellationToken cancellationToken = default)
         {
-            if (globalConnection == null)
+            // The RabbitMQ client's automatic recovery is disabled (EasyRabbitFlow manages recovery itself), so this
+            // long-lived publisher connection is not healed by the client when it drops — it must be re-created here.
+            // Fast path: reuse it while open.
+            if (globalConnection != null && globalConnection.IsOpen)
             {
-                await semaphore.WaitAsync(cancellationToken);
-
-                try
-                {
-                    globalConnection ??= await connectionFactory.CreateConnectionAsync($"Publisher_{connectionId}", cancellationToken);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
+                return globalConnection;
             }
+
+            await semaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                // Replace a connection that closed since the last publish.
+                if (globalConnection != null && !globalConnection.IsOpen)
+                {
+                    try { await globalConnection.DisposeAsync(); } catch { }
+
+                    globalConnection = null;
+                }
+
+                globalConnection ??= await connectionFactory.CreateConnectionAsync($"Publisher_{connectionId}", cancellationToken);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+
             return globalConnection;
         }
 

--- a/src/RabbitFlow/Services/RabbitFlowConfigurator.cs
+++ b/src/RabbitFlow/Services/RabbitFlowConfigurator.cs
@@ -53,13 +53,23 @@ namespace EasyRabbitFlow.Services
                 UserName = hostSettings.Username,
                 Password = hostSettings.Password,
                 VirtualHost = hostSettings.VirtualHost,
-                AutomaticRecoveryEnabled = hostSettings.AutomaticRecoveryEnabled,
-                TopologyRecoveryEnabled = hostSettings.TopologyRecoveryEnabled,
-                NetworkRecoveryInterval = hostSettings.NetworkRecoveryInterval,
+
+                // EasyRabbitFlow owns recovery itself: the consumer re-establishes its connection and channel and
+                // re-declares its full topology on an unexpected shutdown (see ConsumerInstance.TriggerRecoveryAsync).
+                // The client's built-in recovery is intentionally left OFF so the two never run at the same time —
+                // client topology recovery re-binds/re-consumes a recorded topology that does NOT include the main
+                // queue (declared on a throwaway channel), which fails with 404 NOT_FOUND on reconnect. The library's
+                // recovery is configured through HostSettings.AutomaticRecoveryEnabled / NetworkRecoveryInterval.
+                AutomaticRecoveryEnabled = false,
+                TopologyRecoveryEnabled = false,
+
                 RequestedHeartbeat = hostSettings.RequestedHeartbeat
             };
 
             _services.AddSingleton(factory);
+
+            // Registered so the consumer host can read the library-managed recovery settings.
+            _services.AddSingleton(hostSettings);
         }
 
         /// <summary>

--- a/src/RabbitFlow/Settings/RabbitHostSettings.cs
+++ b/src/RabbitFlow/Settings/RabbitHostSettings.cs
@@ -46,34 +46,30 @@ namespace EasyRabbitFlow.Settings
         public string VirtualHost { get; set; } = "/";
 
         /// <summary>
-        /// Gets or sets a value indicating whether automatic connection recovery is enabled.
+        /// Gets or sets a value indicating whether EasyRabbitFlow's own recovery is enabled for consumers.
         /// </summary>
         /// <remarks>
-        /// When enabled, the client will automatically attempt to reconnect to the RabbitMQ broker after a network
-        /// failure or unexpected connection loss. This helps maintain connection stability in production environments
-        /// with transient network issues. 
-        /// The default value is <see langword="true"/>.
+        /// EasyRabbitFlow manages recovery itself: when a consumer's connection or channel shuts down unexpectedly,
+        /// it re-establishes the connection and channel and <b>re-declares its full topology</b> (queue, exchange,
+        /// bindings, dead-letter resources) before resuming consumption. Because of this, the RabbitMQ client's
+        /// built-in automatic/topology recovery is intentionally left disabled — running both at once causes the
+        /// client to re-bind/re-consume a recorded topology that does not include the consumer's main queue,
+        /// surfacing as <c>404 NOT_FOUND</c> on reconnect.
+        /// <para>
+        /// When <see langword="true"/> (the default), a dropped consumer keeps retrying in the background with an
+        /// exponential backoff seeded by <see cref="NetworkRecoveryInterval"/>. When <see langword="false"/>, a
+        /// dropped consumer stays down until the application is restarted.
+        /// </para>
         /// </remarks>
         public bool AutomaticRecoveryEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether automatic topology recovery is enabled after a network failure.
+        /// Gets or sets the base interval used by EasyRabbitFlow's own consumer recovery loop.
         /// </summary>
         /// <remarks>
-        /// When enabled, the system will attempt to restore connections and recover topology
-        /// information automatically if a network interruption occurs. Disabling this property may require manual
-        /// intervention to re-establish connections and recover state.
-        /// The default value is <see langword="true"/>.
-        /// </remarks>
-        public bool TopologyRecoveryEnabled { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the interval to wait between attempts to recover a lost network connection.
-        /// </summary>
-        /// <remarks>
-        /// Specify a duration that determines how long the system waits before retrying network
-        /// recovery after a failure. Adjust this value based on expected network conditions and recovery
-        /// requirements.
+        /// This is the delay before the first recovery attempt; subsequent attempts back off exponentially from this
+        /// value (capped at 30 seconds, or this value when larger). Only meaningful when
+        /// <see cref="AutomaticRecoveryEnabled"/> is <see langword="true"/>.
         /// The default value is <see langword="10"/> seconds.
         /// </remarks>
         public TimeSpan NetworkRecoveryInterval { get; set; } = TimeSpan.FromSeconds(10);

--- a/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
+++ b/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
@@ -538,6 +538,160 @@ public class ConsumerTests
         await Task.WhenAll(stopA, stopB);
     }
 
+    [Fact]
+    public async Task Consumer_RecoversAfterConnectionDrop_AndKeepsConsuming()
+    {
+        // Regression (v8 / 8.0.0-rc.2): a consumer must recover after its connection is dropped and keep
+        // consuming, WITHOUT a topology error.
+        //
+        // In 8.0.0-rc.1 the main queue was declared on a throwaway channel and the RabbitMQ client's built-in
+        // topology recovery was left enabled. On reconnect the client re-bound/re-consumed a recorded topology
+        // that did NOT include the main queue (it was never recorded, the throwaway declare adopted a 406), so
+        // recovery failed with "404 NOT_FOUND - no queue '...'" on queue.bind and the consumer stayed dead.
+        // EasyRabbitFlow now owns recovery (client recovery is off) and re-declares the FULL topology on every
+        // recovery, so the consumer comes back. This test exercises the exact path that broke: AutoGenerate with
+        // an exchange + binding + dead-letter queue.
+        TestConsumer.Reset();
+        EasyRabbitFlow.Tests.Helpers.MemoryLogSink.Reset();
+
+        var queueName = $"test-recovery-{Guid.NewGuid():N}";
+
+        var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
+        {
+            settings.AddConsumer<TestConsumer>(queueName, cfg =>
+            {
+                cfg.AutoGenerate = true;
+                cfg.PrefetchCount = 1;
+                cfg.Timeout = TimeSpan.FromSeconds(10);
+                cfg.ConfigureAutoGenerate(ag =>
+                {
+                    ag.GenerateExchange = true;
+                    ag.ExchangeType = EasyRabbitFlow.Settings.ExchangeType.Direct;
+                    ag.GenerateDeadletterQueue = true;
+                    ag.DurableQueue = false;
+                    ag.DurableExchange = false;
+                    // Must survive the connection drop so recovery re-binds to the SAME existing queue
+                    // (the scenario that produced the 404). An auto-delete queue would be removed when the
+                    // consumer disconnects, changing the test into a create-from-scratch path.
+                    ag.AutoDeleteQueue = false;
+                });
+            });
+        });
+
+        var hostedService = sp.GetServices<IHostedService>().First();
+        await hostedService.StartAsync(CancellationToken.None);
+        await Task.Delay(500);
+
+        var publisher = sp.GetRequiredService<IRabbitFlowPublisher>();
+
+        // Sanity: a message flows before the drop.
+        await publisher.PublishAsync(new TestEvent { Id = "before", Message = "before-drop" }, queueName);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (TestConsumer.ReceivedMessages.Count < 1 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100);
+        }
+        Assert.Single(TestConsumer.ReceivedMessages);
+
+        // Act - force the broker to drop every connection, including the consumer's.
+        var exitCode = await _fixture.CloseAllConnectionsAsync();
+        Assert.Equal(0, exitCode);
+
+        // Give the library's recovery loop time to re-establish the connection, channel and topology.
+        await Task.Delay(3000);
+
+        // Assert - a message published AFTER the drop is consumed, proving the consumer recovered and
+        // re-bound/re-consumed without a 404. (PublishAsync also exercises the publisher's connection
+        // re-creation, since its long-lived connection was dropped too.)
+        var afterResult = await publisher.PublishAsync(new TestEvent { Id = "after", Message = "after-drop" }, queueName);
+
+        deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+        while (TestConsumer.ReceivedMessages.Count < 2 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100);
+        }
+
+        uint depth; uint consumers;
+        using (var probeConn = await _fixture.CreateDirectConnectionAsync())
+        using (var probeCh = await probeConn.CreateChannelAsync())
+        {
+            var ok = await probeCh.QueueDeclarePassiveAsync(queueName);
+            depth = ok.MessageCount;
+            consumers = ok.ConsumerCount;
+        }
+
+        Assert.True(
+            TestConsumer.ReceivedMessages.Count == 2 && TestConsumer.ReceivedMessages.Any(m => m.Id == "after"),
+            $"Consumer did not recover. Received={TestConsumer.ReceivedMessages.Count}, afterPublishSuccess={afterResult.Success}, queueDepth={depth}, consumers={consumers}.\nLOGS:\n{EasyRabbitFlow.Tests.Helpers.MemoryLogSink.Dump()}");
+
+        // Cleanup
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consumer_AdoptsPreexistingQueueWithConflictingArgs_WithoutCrashing()
+    {
+        // Regression (v8): when the auto-generated queue already exists with arguments that differ from the
+        // current configuration (e.g. a previous run created it transient + auto-delete + without a dead-letter
+        // exchange), the consumer must adopt the existing queue and keep running instead of letting the declare
+        // mismatch (PRECONDITION_FAILED / 406) propagate and crash host startup. This is the visible half of the
+        // QA failure: the "[RABBIT-FLOW]: Queue '...' already exists with arguments that differ" warning followed
+        // by a hard 404 that took the host down.
+        TestConsumer.Reset();
+
+        var queueName = $"test-adopt-{Guid.NewGuid():N}";
+
+        // Seed the queue with arguments that differ from what the consumer requests below (consumer wants a
+        // durable queue with a dead-letter exchange; this one is transient, auto-delete and has no DLX), so the
+        // consumer's declare hits a 406 and must take the adopt path.
+        using (var seedConn = await _fixture.CreateDirectConnectionAsync())
+        using (var seedCh = await seedConn.CreateChannelAsync())
+        {
+            await seedCh.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true, arguments: null);
+        }
+
+        var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
+        {
+            settings.AddConsumer<TestConsumer>(queueName, cfg =>
+            {
+                cfg.AutoGenerate = true;
+                cfg.PrefetchCount = 1;
+                cfg.Timeout = TimeSpan.FromSeconds(10);
+                cfg.ConfigureAutoGenerate(ag =>
+                {
+                    ag.GenerateExchange = true;
+                    ag.ExchangeType = EasyRabbitFlow.Settings.ExchangeType.Direct;
+                    ag.GenerateDeadletterQueue = true;   // adds x-dead-letter-* args -> mismatch vs the seeded queue
+                    ag.DurableQueue = true;              // mismatch: seeded queue is transient
+                    ag.DurableExchange = false;
+                    ag.AutoDeleteQueue = false;          // mismatch: seeded queue is auto-delete
+                });
+            });
+        });
+
+        var hostedService = sp.GetServices<IHostedService>().First();
+
+        // Must NOT throw: the 406 is adopted, not propagated to the host.
+        await hostedService.StartAsync(CancellationToken.None);
+        await Task.Delay(500);
+
+        // The adopted queue is usable end-to-end.
+        var publisher = sp.GetRequiredService<IRabbitFlowPublisher>();
+        await publisher.PublishAsync(new TestEvent { Id = "adopt-1", Message = "adopted" }, queueName);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (TestConsumer.ReceivedMessages.Count == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100);
+        }
+
+        Assert.Single(TestConsumer.ReceivedMessages);
+        Assert.Equal("adopt-1", TestConsumer.ReceivedMessages[0].Id);
+
+        await hostedService.StopAsync(CancellationToken.None);
+    }
+
     [Theory]
     [InlineData(typeof(AlwaysDerivedTransientFailConsumer), true)]   // subclass of RabbitFlowTransientException
     [InlineData(typeof(AlwaysFailConsumer), false)]                  // InvalidOperationException

--- a/tests/EasyRabbitFlow.Tests/Fixtures/RabbitMqFixture.cs
+++ b/tests/EasyRabbitFlow.Tests/Fixtures/RabbitMqFixture.cs
@@ -1,6 +1,7 @@
 using EasyRabbitFlow;
 using EasyRabbitFlow.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using RabbitMQ.Client;
 using Testcontainers.RabbitMq;
@@ -59,7 +60,10 @@ public class RabbitMqFixture : IAsyncLifetime
     public IServiceProvider BuildServiceProviderWithConsumers(Action<RabbitFlowConfigurator> configure)
     {
         var services = new ServiceCollection();
-        services.AddLogging();
+
+        // Capture library logs into a static buffer so timing-sensitive tests (e.g. recovery) can surface what
+        // the library actually did on failure. See MemoryLogSink.
+        services.AddLogging(b => b.AddProvider(new EasyRabbitFlow.Tests.Helpers.MemoryLoggerProvider()).SetMinimumLevel(LogLevel.Debug));
 
         services.AddRabbitFlow(settings =>
         {
@@ -77,6 +81,17 @@ public class RabbitMqFixture : IAsyncLifetime
         services.UseRabbitFlowConsumers();
 
         return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Forces the broker to drop every open connection (consumers, publisher, verification),
+    /// simulating an abrupt network/broker outage so recovery paths can be exercised.
+    /// Returns the <c>rabbitmqctl</c> exit code (0 on success).
+    /// </summary>
+    public async Task<long> CloseAllConnectionsAsync(string reason = "regression-test")
+    {
+        var result = await _container.ExecAsync(new[] { "rabbitmqctl", "close_all_connections", reason });
+        return result.ExitCode ?? -1;
     }
 
     /// <summary>

--- a/tests/EasyRabbitFlow.Tests/Helpers/MemoryLogSink.cs
+++ b/tests/EasyRabbitFlow.Tests/Helpers/MemoryLogSink.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace EasyRabbitFlow.Tests.Helpers;
+
+// Test-only logger that captures log lines into a static, thread-safe buffer so a test can assert on
+// (or dump) what the library logged. Useful for diagnosing recovery/topology behavior under Testcontainers.
+public static class MemoryLogSink
+{
+    public static readonly ConcurrentQueue<string> Lines = new();
+
+    public static void Reset() => Lines.Clear();
+
+    public static string Dump() => string.Join(Environment.NewLine, Lines);
+}
+
+public sealed class MemoryLoggerProvider : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new MemoryLogger();
+
+    public void Dispose() { }
+
+    private sealed class MemoryLogger : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            MemoryLogSink.Lines.Enqueue($"{DateTime.UtcNow:HH:mm:ss.fff} {logLevel}: {message}{(exception != null ? " | " + exception.GetType().Name + ": " + exception.Message : string.Empty)}");
+        }
+    }
+}


### PR DESCRIPTION
….0-rc.2)

Fixes a startup crash on RabbitMQ.Client 7 when an auto-generated queue already exists with arguments that differ from the current configuration and the broker deletes it mid-setup (a stale auto-delete/x-expires queue whose previous consumer just disconnected - common with an Aspire broker that survives app restarts). The consumer adopted the existing queue on a 406, then hit a 404 NOT_FOUND on queue.bind that propagated out of StartAsync and took the whole host down.

Changes:
- ConsumerInstance: bounded retry around topology declare + consume; on a 404 during setup the queue is recreated with the current arguments (it no longer exists, so there is no mismatch) and bind/consume retried.
- ConsumerInstance.StartAsync: a consumer that fails to set up no longer crashes host startup; it logs and (when recovery is enabled) retries in the background.
- Recovery is now fully library-owned: the RabbitMQ client built-in automatic/topology recovery is disabled on the connections we manage (running both re-bound a recorded topology missing the main queue, 404). HostSettings.AutomaticRecoveryEnabled now toggles the library own recovery and NetworkRecoveryInterval seeds its backoff; TopologyRecoveryEnabled removed.
- Recovery correctness: when the connection is recreated, the stale channel (which can keep reporting IsOpen == true) is dropped so the consumer is actually re-attached instead of silently leaving the queue with no consumer.
- Recovery speed: disposing a force-closed connection (which blocks up to the client ContinuationTimeout, ~20s) is offloaded so it no longer stalls recovery or shutdown.
- Publisher: its long-lived connection is re-created when closed, since the client no longer auto-recovers it.