### PR TITLE
fix: RabbitMQ 4.x compatibility — strip rejected x-consumer-timeout, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ See the [Breaking Changes](#️-breaking-changes-v800) section below before upgr
 
 ---
 
+## RabbitMQ 4.x compatibility
+
+EasyRabbitFlow works against **RabbitMQ 3.13+ and 4.x**. RabbitMQ 4.x introduced a few server-side changes that affect queue declaration; here's how the library handles them:
+
+- **`x-consumer-timeout` on classic queues (4.x rejects it).** In 4.x, *classic queues no longer evaluate consumer timeouts* — the `x-consumer-timeout` argument is only valid for quorum queues/streams, and declaring a classic queue with it fails (`PRECONDITION_FAILED - invalid arg 'x-consumer-timeout' ... of queue type rabbit_classic_queue`). Older releases of this library always set that argument on the auto-generated queue, so on RabbitMQ 4.x the main queue could not be created. **Fixed in v8.0.0-rc.2:** when the broker rejects the argument, the consumer logs a warning, **re-declares the queue without `x-consumer-timeout`, and continues** — so `AutoGenerate` works on both 3.x and 4.x with no code change.
+  - Your per-message handler timeout (`ConsumerSettings.Timeout`) is **unaffected**: it is enforced by the library itself (a `CancellationToken`), not by the broker. On 4.x classic queues the broker no longer kills a consumer for a slow ack at all; if you need a broker-side per-queue timeout, use a quorum queue with a `consumer_timeout` policy.
+
+- **Transient non-exclusive queues are denied by default (`transient_nonexcl_queues`).** RabbitMQ 4.x rejects queues that are **both non-durable and non-exclusive** (`INTERNAL_ERROR - Feature 'transient_nonexcl_queues' is deprecated`). The library's default is `DurableQueue = true`, so the default configuration is safe. **Only if you explicitly set `DurableQueue = false`** on a consumer will 4.x reject it — keep the queue durable (recommended) or enable `deprecated_features.permit.transient_nonexcl_queues = true` on the broker. Temporary queues created via `IRabbitFlowTemporary` are **exclusive**, so they are unaffected.
+
+- **Not affected:** the library uses per-consumer QoS (`global: false`), so the deprecation of global QoS does not apply, and it never sets the removed CQv1 arguments (`x-queue-mode`, `x-queue-version = 1`).
+
+---
+
 ## Documentation
 
 | Guide | Contents |

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -165,7 +165,7 @@ cfg.AddConsumer<OrderConsumer>("orders-queue", c =>
 | `ExchangeName` | string? | `null` | Custom name (defaults to `{queue}-exchange`) |
 | `RoutingKey` | string? | `null` | Custom routing key (defaults to `{queue}-routing-key`) |
 | `DurableExchange` | bool | `true` | Exchange survives broker restart |
-| `DurableQueue` | bool | `true` | Queue survives broker restart |
+| `DurableQueue` | bool | `true` | Queue survives broker restart. **Keep `true` on RabbitMQ 4.x:** the broker denies non-durable, non-exclusive queues by default (`transient_nonexcl_queues` deprecated), so `DurableQueue = false` on a non-exclusive consumer queue is rejected. See [RabbitMQ 4.x compatibility](../README.md#rabbitmq-4x-compatibility). |
 | `ExclusiveQueue` | bool | `false` | Queue limited to declaring connection |
 | `AutoDeleteQueue` | bool | `false` | Delete queue when last consumer disconnects |
 | `Args` | IDictionary? | `null` | Additional RabbitMQ arguments |
@@ -236,6 +236,12 @@ x-consumer-timeout = max(60s, Timeout × (MaxRetryCount + 1) + RetryInterval × 
 ```
 
 The value is floored at 60s because RabbitMQ rejects consumer timeouts below one minute. This keeps the broker-side policy in sync with your configured retry behavior, so the broker never kills a consumer mid-retry.
+
+> **ℹ️ RabbitMQ 4.x: classic queues no longer evaluate consumer timeouts**
+>
+> Starting with RabbitMQ 4.x, *classic queues and streams no longer evaluate consumer timeouts* — the per-queue `x-consumer-timeout` argument is only valid for **quorum queues**, and declaring a **classic** queue with it is rejected (`PRECONDITION_FAILED - invalid arg 'x-consumer-timeout' ... of queue type rabbit_classic_queue`). EasyRabbitFlow declares classic queues, so on 4.x it **detects this rejection, re-declares the queue without `x-consumer-timeout`, and continues** (logging a warning once). This is automatic and needs no configuration — `AutoGenerate` works on both 3.13 and 4.x.
+>
+> The practical effect on 4.x: there is **no broker-side delivery-ack timeout on classic queues**, so a slow handler is never killed by the broker. Your per-message `Timeout` above is still enforced **by the library** (a `CancellationToken`), independent of the broker. If you specifically need a broker-enforced per-queue timeout on 4.x, use a quorum queue with a `consumer_timeout` policy.
 
 > **⚠️ `x-consumer-timeout` only applies when the queue is first created**
 >

--- a/src/RabbitFlow/Services/ConsumerHostedService.cs
+++ b/src/RabbitFlow/Services/ConsumerHostedService.cs
@@ -137,6 +137,9 @@ namespace EasyRabbitFlow.Services
         private string _deadLetterRoutingKey = string.Empty;
         private volatile bool _stopping;
         private volatile bool _rebuilding;
+        // Set once the broker rejects the 'x-consumer-timeout' queue argument (RabbitMQ 4.x), so later (re)declares
+        // and recovery passes don't keep re-adding it and paying the extra rejected round trip.
+        private volatile bool _consumerTimeoutArgRejected;
         private int _stopped;
         private CancellationToken _lifetimeCt;
 
@@ -541,7 +544,9 @@ namespace EasyRabbitFlow.Services
             // RabbitMQ treats it as optional and silently ignores a changed value on redeclare (no
             // PRECONDITION_FAILED), so changing Timeout/MaxRetryCount/RetryInterval on an existing queue does NOT
             // update it — the queue must be deleted and recreated (or a consumer-timeout policy applied) to change it.
-            if (!args.ContainsKey("x-consumer-timeout"))
+            // Skipped once the broker has rejected it (RabbitMQ 4.x doesn't accept it on queue.declare); see
+            // DeclareOrAdoptMainQueueAsync.
+            if (!args.ContainsKey("x-consumer-timeout") && !_consumerTimeoutArgRejected)
             {
                 args["x-consumer-timeout"] = _serverConsumerTimeoutMs;
             }
@@ -566,20 +571,98 @@ namespace EasyRabbitFlow.Services
         // consumer beats one that won't start and silently leaves the system idle.
         private async Task DeclareOrAdoptMainQueueAsync(bool durable, bool exclusive, bool autoDelete, IDictionary<string, object?> args, CancellationToken ct)
         {
-            try
+            // Each fragile declare runs on its own throwaway channel so a 406 can't take the consumer's channel down.
+            while (true)
             {
-                using var declareChannel = await _connection!.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+                try
+                {
+                    using var declareChannel = await _connection!.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
 
-                await declareChannel.QueueDeclareAsync(_queueName, durable, exclusive, autoDelete, args, cancellationToken: ct).ConfigureAwait(false);
-            }
-            catch (OperationInterruptedException ex) when (ex.ShutdownReason?.ReplyCode == 406)
-            {
-                _logger.LogWarning(
-                    "[RABBIT-FLOW]: Queue '{Queue}' already exists with arguments that differ from the current configuration " +
-                    "(e.g. x-dead-letter-exchange/-routing-key, x-max-priority, or custom Args). " +
-                    "The consumer for {Consumer} will keep running against the EXISTING queue and its current arguments. " +
-                    "To apply the new arguments, delete queue '{Queue}' and let the consumer recreate it.",
-                    _queueName, _consumerType.Name, _queueName);
+                    await declareChannel.QueueDeclareAsync(_queueName, durable, exclusive, autoDelete, args, cancellationToken: ct).ConfigureAwait(false);
+
+                    return;
+                }
+                catch (OperationInterruptedException ex) when (ex.ShutdownReason?.ReplyCode == 406)
+                {
+                    var brokerReason = ex.ShutdownReason?.ReplyText;
+
+                    // RabbitMQ 4.x rejects the per-queue 'x-consumer-timeout' argument that 3.13 accepted
+                    // ("PRECONDITION_FAILED - invalid arg 'x-consumer-timeout' ... of queue type rabbit_classic_queue").
+                    // It's a derived convenience, not user data, so drop it and re-declare: the broker-wide
+                    // consumer_timeout (default 30 min) applies instead, and a longer per-queue timeout can still be
+                    // set with a `consumer_timeout` policy. This keeps AutoGenerate working across 3.x and 4.x.
+                    if (args.ContainsKey("x-consumer-timeout")
+                        && (brokerReason?.IndexOf("x-consumer-timeout", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
+                    {
+                        _logger.LogWarning(
+                            "[RABBIT-FLOW]: Broker rejected the 'x-consumer-timeout' queue argument for '{Queue}' ({Consumer}); " +
+                            "this RabbitMQ version does not accept it on queue.declare. Re-declaring '{Queue}' without it — the " +
+                            "broker-wide consumer_timeout applies. Set a 'consumer_timeout' policy if you need a longer per-queue timeout. " +
+                            "Broker reason: {Reason}",
+                            _queueName, _consumerType.Name, _queueName, brokerReason);
+
+                        args.Remove("x-consumer-timeout");
+
+                        _consumerTimeoutArgRejected = true;
+
+                        continue;
+                    }
+
+                    // Otherwise a 406 means one of two different things:
+                    //   (a) the queue ALREADY EXISTS with arguments that differ from ours, or
+                    //   (b) the broker REJECTED the declare (an argument it won't accept, or a policy that conflicts
+                    //       with the requested arguments/queue-type) and the queue was NOT created.
+                    // We must not treat (b) as (a): adopting then binding/consuming a queue that doesn't exist yields a
+                    // misleading "already exists" warning followed by a 404 loop. A passive declare (which never
+                    // compares arguments) tells them apart.
+                    bool exists;
+
+                    try
+                    {
+                        using var probe = await _connection!.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+
+                        await probe.QueueDeclarePassiveAsync(_queueName, ct).ConfigureAwait(false);
+
+                        exists = true;
+                    }
+                    catch (OperationInterruptedException probeEx) when (probeEx.ShutdownReason?.ReplyCode == 404)
+                    {
+                        exists = false;
+                    }
+
+                    if (exists)
+                    {
+                        // (a) Adopt the existing queue as-is and keep running against its current arguments.
+                        _logger.LogWarning(
+                            "[RABBIT-FLOW]: Queue '{Queue}' already exists with arguments that differ from the current configuration " +
+                            "(e.g. x-dead-letter-exchange/-routing-key, x-max-priority, or custom Args). " +
+                            "The consumer for {Consumer} will keep running against the EXISTING queue and its current arguments. " +
+                            "To apply the new arguments, delete queue '{Queue}' and let the consumer recreate it. Broker reason: {Reason}",
+                            _queueName, _consumerType.Name, _queueName, brokerReason);
+
+                        return;
+                    }
+
+                    // (b) The declare was rejected and the queue does not exist. Surface the broker's actual reason
+                    // instead of pretending to adopt; binding/consuming would only fail with 404. The caller's setup
+                    // fails cleanly (the host still starts; recovery keeps retrying), and the operator gets the real cause.
+                    throw new RabbitFlowException(
+                        $"[RABBIT-FLOW]: Failed to declare queue '{_queueName}' for {_consumerType.Name}: the broker rejected the " +
+                        $"declare with PRECONDITION_FAILED and the queue does not exist. This is NOT an \"already exists\" mismatch — " +
+                        $"it usually means an argument value is not accepted by the broker, or a broker policy conflicts with the " +
+                        $"requested arguments or queue-type. Broker reason: {brokerReason}", ex);
+                }
+                catch (OperationInterruptedException ex)
+                {
+                    // Any other broker-side rejection of the declare (e.g. 405 RESOURCE_LOCKED, 530 NOT_ALLOWED,
+                    // 541 deprecated-feature like transient_nonexcl_queues, ...). Never swallow the broker's reason:
+                    // log the code and ReplyText with context, then rethrow so setup fails cleanly and recovery retries.
+                    _logger.LogError(ex,
+                        "[RABBIT-FLOW]: Unexpected broker error declaring queue '{Queue}' for {Consumer}. ReplyCode: {Code}, Broker reason: {Reason}",
+                        _queueName, _consumerType.Name, ex.ShutdownReason?.ReplyCode, ex.ShutdownReason?.ReplyText);
+
+                    throw;
+                }
             }
         }
 

--- a/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
+++ b/tests/EasyRabbitFlow.Tests/ConsumerTests.cs
@@ -39,7 +39,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -95,8 +95,8 @@ public class ConsumerTests
                     ag.GenerateExchange = true;
                     ag.ExchangeType = EasyRabbitFlow.Settings.ExchangeType.Direct;
                     ag.GenerateDeadletterQueue = true;
-                    ag.DurableQueue = false;
-                    ag.DurableExchange = false;
+                    ag.DurableQueue = true;
+                    ag.DurableExchange = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -148,7 +148,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -201,7 +201,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -259,7 +259,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -326,7 +326,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -397,7 +397,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = true;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.DurableExchange = false;
                     ag.AutoDeleteQueue = true;
                 });
@@ -490,7 +490,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -522,7 +522,7 @@ public class ConsumerTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -568,7 +568,7 @@ public class ConsumerTests
                     ag.GenerateExchange = true;
                     ag.ExchangeType = EasyRabbitFlow.Settings.ExchangeType.Direct;
                     ag.GenerateDeadletterQueue = true;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.DurableExchange = false;
                     // Must survive the connection drop so recovery re-binds to the SAME existing queue
                     // (the scenario that produced the 404). An auto-delete queue would be removed when the
@@ -648,7 +648,7 @@ public class ConsumerTests
         using (var seedConn = await _fixture.CreateDirectConnectionAsync())
         using (var seedCh = await seedConn.CreateChannelAsync())
         {
-            await seedCh.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true, arguments: null);
+            await seedCh.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true, arguments: null);
         }
 
         var sp = _fixture.BuildServiceProviderWithConsumers(settings =>
@@ -716,7 +716,7 @@ public class ConsumerTests
                     {
                         ag.GenerateExchange = false;
                         ag.GenerateDeadletterQueue = true;
-                        ag.DurableQueue = false;
+                        ag.DurableQueue = true;
                         ag.DurableExchange = false;
                         ag.AutoDeleteQueue = true;
                     });

--- a/tests/EasyRabbitFlow.Tests/Fixtures/RabbitMqFixture.cs
+++ b/tests/EasyRabbitFlow.Tests/Fixtures/RabbitMqFixture.cs
@@ -10,7 +10,9 @@ namespace EasyRabbitFlow.Tests.Fixtures;
 
 public class RabbitMqFixture : IAsyncLifetime
 {
-    private readonly RabbitMqContainer _container = new RabbitMqBuilder("rabbitmq:3.13-management")
+    // RabbitMQ 4.x (matches what Aspire provisions). 4.x is stricter than 3.13: notably it rejects the
+    // 'x-consumer-timeout' queue argument on queue.declare, which the consumer must tolerate.
+    private readonly RabbitMqContainer _container = new RabbitMqBuilder("rabbitmq:4.3-management")
         .WithUsername("guest")
         .WithPassword("guest")
         .Build();

--- a/tests/EasyRabbitFlow.Tests/HealthCheckTests.cs
+++ b/tests/EasyRabbitFlow.Tests/HealthCheckTests.cs
@@ -48,7 +48,7 @@ public class HealthCheckTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var result = await RunCheckAsync(o => o.Queues.Add(queueName));
 
@@ -73,7 +73,7 @@ public class HealthCheckTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var result = await RunCheckAsync(o =>
         {

--- a/tests/EasyRabbitFlow.Tests/PublisherTests.cs
+++ b/tests/EasyRabbitFlow.Tests/PublisherTests.cs
@@ -29,7 +29,7 @@ public class PublisherTests
         // Pre-declare queue
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var evt = new TestEvent { Id = "1", Message = "hello" };
 
@@ -57,7 +57,7 @@ public class PublisherTests
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
         await ch.ExchangeDeclareAsync(exchangeName, "direct", durable: false, autoDelete: true);
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
         await ch.QueueBindAsync(queueName, exchangeName, routingKey);
 
         var evt = new TestEvent { Id = "2", Message = "routed" };
@@ -93,7 +93,7 @@ public class PublisherTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var evt = new TestEvent { Id = "42", Message = "content-check" };
 

--- a/tests/EasyRabbitFlow.Tests/PurgerTests.cs
+++ b/tests/EasyRabbitFlow.Tests/PurgerTests.cs
@@ -27,7 +27,7 @@ public class PurgerTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         // Publish 5 messages
         for (int i = 0; i < 5; i++)
@@ -61,8 +61,8 @@ public class PurgerTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queue1, durable: false, exclusive: false, autoDelete: true);
-        await ch.QueueDeclareAsync(queue2, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queue1, durable: true, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queue2, durable: true, exclusive: false, autoDelete: true);
 
         var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestEvent { Id = "1" }));
         await ch.BasicPublishAsync("", queue1, body);

--- a/tests/EasyRabbitFlow.Tests/ReprocessorTests.cs
+++ b/tests/EasyRabbitFlow.Tests/ReprocessorTests.cs
@@ -31,8 +31,8 @@ public class ReprocessorTests
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
 
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: false);
-        await ch.QueueDeclareAsync(dlqName, durable: false, exclusive: false, autoDelete: false);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: false);
+        await ch.QueueDeclareAsync(dlqName, durable: true, exclusive: false, autoDelete: false);
 
         try
         {

--- a/tests/EasyRabbitFlow.Tests/StateTests.cs
+++ b/tests/EasyRabbitFlow.Tests/StateTests.cs
@@ -27,7 +27,7 @@ public class StateTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var state = sp.GetRequiredService<IRabbitFlowState>();
 
@@ -47,7 +47,7 @@ public class StateTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestEvent { Id = "1" }));
         await ch.BasicPublishAsync("", queueName, body);
@@ -71,7 +71,7 @@ public class StateTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         // Publish 3 messages
         for (int i = 0; i < 3; i++)
@@ -99,7 +99,7 @@ public class StateTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(queueName, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(queueName, durable: true, exclusive: false, autoDelete: true);
 
         for (int i = 0; i < 2; i++)
         {
@@ -150,7 +150,7 @@ public class StateTests
 
         using var conn = await _fixture.CreateDirectConnectionAsync();
         using var ch = await conn.CreateChannelAsync();
-        await ch.QueueDeclareAsync(existingQueue, durable: false, exclusive: false, autoDelete: true);
+        await ch.QueueDeclareAsync(existingQueue, durable: true, exclusive: false, autoDelete: true);
 
         var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestEvent { Id = "1" }));
         await ch.BasicPublishAsync("", existingQueue, body);

--- a/tests/EasyRabbitFlow.Tests/TracingTests.cs
+++ b/tests/EasyRabbitFlow.Tests/TracingTests.cs
@@ -51,7 +51,7 @@ public class TracingTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });
@@ -110,7 +110,7 @@ public class TracingTests
                 {
                     ag.GenerateExchange = false;
                     ag.GenerateDeadletterQueue = false;
-                    ag.DurableQueue = false;
+                    ag.DurableQueue = true;
                     ag.AutoDeleteQueue = true;
                 });
             });


### PR DESCRIPTION
…surface broker reasons

RabbitMQ 4.x no longer evaluates consumer timeouts on classic queues and rejects the 'x-consumer-timeout' queue argument on queue.declare ("PRECONDITION_FAILED - invalid arg 'x-consumer-timeout' ... of queue type rabbit_classic_queue"). Because AutoGenerate always set that argument, the main queue could not be declared on 4.x and the consumer failed to start (the dead-letter queue/exchange were created, the main queue was not).

- DeclareOrAdoptMainQueueAsync now distinguishes the three meanings of a 406 instead of assuming "already exists": on the x-consumer-timeout rejection it logs a warning, re-declares the queue WITHOUT the argument and continues (works on 3.13 and 4.x); on a genuine arg mismatch it adopts the existing queue (verified via passive declare); on a rejected declare for a queue that does not exist it throws with the broker's real reason instead of binding a non-existent queue.
- Never swallow the broker's ReplyText again: the 406 path logs "Broker reason: ..." and a new catch logs any other OperationInterruptedException (405/530/541/...) with code + reason before rethrowing.
- Skip re-adding x-consumer-timeout on later (re)declares/recovery once the broker has rejected it.

Tests:
- Fixture now runs against rabbitmq:4.3-management (what Aspire provisions) instead of 3.13.
- Migrated test queues from non-durable to durable: RabbitMQ 4.x denies transient non-exclusive queues by default (transient_nonexcl_queues deprecated). The library default (DurableQueue = true) was already safe.

Docs:
- README: new "RabbitMQ 4.x compatibility" section.
- consumers.md: 4.x consumer-timeout note and a DurableQueue warning for 4.x.